### PR TITLE
feat: add Lab 2 data model and seed data

### DIFF
--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -21,8 +21,8 @@ For each Lab 2 feature:
 
 | Issue | Feature branch | Pull request | Reviewer | Result |
 | --- | --- | --- | --- | --- |
-| #11 | `feature/11-lab2-contract` | To be added | To be added | In progress |
-| #12 | `feature/12-data-and-seed` | To be added | To be added | Not started |
+| #11 | `feature/11-lab2-contract` | [PR #19](https://github.com/Thanwarat1303/toktickit/pull/19) | mxckiexz | Approved and merged |
+| #12 | `feature/12-data-seed` | To be added | mxckiexz | In progress |
 | #13 | `feature/13-requester-selection` | To be added | To be added | Not started |
 | #14 | `feature/14-create-ticket-api` | To be added | To be added | Not started |
 | #15 | `feature/15-create-ticket-ui` | To be added | To be added | Not started |
@@ -48,7 +48,7 @@ My response:
 
 Resolution:
 
-> Changes completed. Waiting for the reviewer to re-check the updated pull request.
+> Changes completed. The reviewer approved the updated pull request, and PR #19 was merged into `lab2-staging`.
 
 ## Pull Requests I Reviewed for My Peer
 

--- a/docs/lab-02/specification.md
+++ b/docs/lab-02/specification.md
@@ -24,9 +24,9 @@ Each ticket must contain a requester, category, related system, summary, descrip
 - Backend API for creating tickets.
 - Backend-generated unique ticket numbers.
 - Default ticket status of `New`.
-- My Tickets page with search, filter, sorting, and pagination.
+- My Tickets page with search, filtering, sorting, and pagination.
 - Ticket detail page for the ticket owner.
-- - Attachment upload, metadata display, download, and soft removal for the ticket owner.
+- Attachment upload, metadata display, download, and soft removal for the ticket owner.
 - Automated API and frontend tests.
 - Engineering documents, peer review, GitHub Project board, pull requests, and evidence for the lab submission.
 
@@ -37,14 +37,14 @@ Each ticket must contain a requester, category, related system, summary, descrip
 - Email notifications.
 - Production deployment.
 - Complex file preview features.
+
 ## 4. Functional Requirements
 
 ### FR-01: Development Requester Selection
 
-The application must show a Development Requester selector.  
-The selected requester is used as the current user for local testing.
+The application must show a Development Requester selector.
 
-Only active requesters can be selected. Changing the selected requester must update the tickets shown in My Tickets.
+The selected requester is used as the current user for local testing. Only active requesters can be selected. Changing the selected requester must update the tickets shown in My Tickets.
 
 ### FR-02: Reference Data
 
@@ -84,22 +84,26 @@ The page must show the ticket number, status, requester, category, related syste
 ### FR-06: Attachments
 
 The requester must be able to upload, view metadata for, download, and soft-remove attachments for their own ticket.
+
 Before soft removal, the requester must provide a removal reason and confirm the action.
-A removed attachment remains visible as metadata in Ticket Detail, but it cannot be downloaded or previewed. The system must reject unsupported files or files that exceed the allowed size.
+
+A removed attachment remains visible as metadata in Ticket Detail, but it cannot be downloaded or previewed.
+
+The system must reject unsupported files or files that exceed the allowed size.
 
 ## 5. Business Rules
 
-BR-01: The backend generates the ticket number. The ticket number must be unique and must not be created by the frontend.
-BR-02: A newly created ticket must have the status New.
-BR-03: Only active categories, related systems, and requesters can be used when creating a ticket.
-BR-04: Summary and description are required. Summary must not be longer than 100 characters. Description must not be longer than 2,000 characters.
-BR-05: Priority must be one of Low, Medium, or High.
-BR-06: A requester can view only their own tickets and ticket details.
-BR-07: The system must prevent duplicate ticket submissions when the same requester submits the same ticket data more than once within a short period.
-BR-08: Allowed attachment types are JPG/JPEG, PNG, WEBP, and PDF. Each file must not be larger than 5 MB.
-BR-09: A ticket can have at most five active attachments.
-BR-10: Attachment removal must use soft removal. The attachment metadata remains in the database, but a removed attachment cannot be downloaded or previewed.
-BR-11: Only the ticket owner can upload or soft-remove an attachment. A removal reason is required before an attachment is soft-removed.
+- BR-01: The backend generates the ticket number. The ticket number must be unique and must not be created by the frontend.
+- BR-02: A newly created ticket must have the status `New`.
+- BR-03: Only active categories, related systems, and requesters can be used when creating a ticket.
+- BR-04: Summary and description are required. Summary must not be longer than 100 characters. Description must not be longer than 2,000 characters.
+- BR-05: Priority must be one of `Low`, `Medium`, or `High`.
+- BR-06: A requester can view only their own tickets and ticket details.
+- BR-07: The system must prevent duplicate ticket submissions when the same requester submits the same ticket data more than once within a short period.
+- BR-08: Allowed attachment types are JPG/JPEG, PNG, WEBP, and PDF. Each file must not be larger than 5 MB.
+- BR-09: A ticket can have at most five active attachments.
+- BR-10: Attachment removal must use soft removal. The attachment metadata remains in the database, but a removed attachment cannot be downloaded or previewed.
+- BR-11: Only the ticket owner can upload or soft-remove an attachment. A removal reason is required before an attachment is soft-removed.
 
 ## 6. UI Specification Summary
 
@@ -118,20 +122,40 @@ The page should use consistent colors, spacing, buttons, validation messages, lo
 
 The database needs the following data models:
 
-Category — includes an isActive field.
-RelatedSystem — includes a name and an isActive field.
-Requester — includes name, email, and an isActive field.
-Ticket — stores ticket number, requester, category, related system, summary, description, priority, status, and timestamps.
-Attachment — belongs to one ticket and stores originalFilename, storedFilename, mimeType, sizeBytes, createdAt, removedAt, and removalReason.
+- `Category` — includes a unique name, an `isActive` field, and a creation timestamp.
+- `RelatedSystem` — includes a unique name, an `isActive` field, and a creation timestamp.
+- `Requester` — includes name, unique email, an `isActive` field, and a creation timestamp.
+- `Ticket` — stores ticket number, requester, category, related system, summary, description, priority, status, and timestamps.
+- `Attachment` — belongs to one ticket and stores `originalFilename`, `storedFilename`, `mimeType`, `sizeBytes`, `createdAt`, `removedAt`, and `removalReason`.
 
-The Attachment model uses removedAt as the soft-removal marker. An active attachment has removedAt = null. A removed attachment keeps its metadata for audit purposes but must not be downloadable or previewable.
-The database should include an index for ticketId because attachments are commonly loaded by ticket. Ticket number must be unique.
+The `Attachment` model uses `removedAt` as the soft-removal marker. An active attachment has `removedAt = null`.
 
-Seed data must include at least:
-4 required categories: Account and Access, Hardware, Software, and Network
-6 related systems
-4 active requesters
-1 inactive requester
+A removed attachment keeps its metadata for audit purposes but must not be downloadable or previewable.
+
+The database includes an index for `Attachment.ticketId` because attachments are commonly loaded by ticket. The ticket number must be unique.
+
+The seed data includes:
+
+- Four active required categories: Account and Access, Hardware, Software, and Network
+- One inactive category: Legacy Service
+- Seven active related systems
+- One inactive related system: Legacy Student Portal
+- Four active development requesters
+- One inactive development requester
+
+The seed uses `upsert` with unique category names, related-system names, and requester emails. It can therefore be executed repeatedly without creating duplicate seed records.
+
+### Future Schema Evolution for Lab 3
+
+Lab 2 uses the `Requester` model and the Development Requester selector for local testing without real authentication.
+
+In Lab 3, requester identity will be connected to a real authenticated user. The database may introduce a `User` model to store authentication information such as login identity and password-related data.
+
+The existing `Requester` model can remain as a requester profile linked to one authenticated `User`, or its profile fields can be migrated into the authenticated user model.
+
+The `requesterId` relationship on `Ticket` must be preserved or migrated safely so that existing tickets continue to belong to the correct requester after authentication is introduced.
+
+Authentication secrets and password hashes must not be stored directly in the existing development requester selector.
 
 ## 8. API Contract
 
@@ -141,7 +165,10 @@ The backend will provide APIs for:
 - Creating a ticket.
 - Reading the current requester's ticket list.
 - Reading one ticket only when it belongs to the current requester.
-- Uploading, retrieving attachment metadata, downloading active attachments, and soft-removing attachments only when the ticket belongs to the current requester.
+- Uploading attachments for a ticket owned by the current requester.
+- Retrieving attachment metadata.
+- Downloading active attachments.
+- Soft-removing attachments owned by the current requester.
 
 Each API must validate input and return safe error messages. The detailed request and response formats are documented in `api-spec.md`.
 
@@ -149,7 +176,7 @@ Each API must validate input and return safe error messages. The detailed reques
 
 ### AC-01 — Development Requester Selection
 
-**Given** active requesters exist,  
+**Given** active and inactive requesters exist,  
 **When** the user opens the requester selection screen,  
 **Then** the system displays only active requesters and allows one requester to be selected.
 
@@ -203,7 +230,16 @@ Each API must validate input and return safe error messages. The detailed reques
 
 ## 10. Definition of Done
 
-This sprint is done when the feature works according to the acceptance criteria, tests pass, the code is committed to a feature branch, a pull request is opened to `lab2-staging`, a peer review is completed, and the documentation is updated.
+This sprint is done when:
+
+- The implementation satisfies the acceptance criteria.
+- Automated tests pass.
+- The frontend and backend builds pass.
+- The code is committed to the correct feature branch.
+- A pull request is opened to `lab2-staging`.
+- A peer review and approval are completed.
+- The GitHub Project board is updated.
+- The Lab 2 documents and submission evidence are updated.
 
 ## 11. Assumptions and Decisions
 
@@ -211,4 +247,6 @@ This sprint is done when the feature works according to the acceptance criteria,
 - PostgreSQL and Prisma are used for persistent data.
 - The selected requester identity is sent with requests only for development and testing.
 - Ticket numbers are created by the backend because the frontend must not control unique business identifiers.
-- The project will use the existing GitHub Project board to track issue status.
+- The project uses the existing GitHub Project board to track issue status.
+- Inactive category and related-system fixtures are included so that BR-03 and AC-04 can be tested during the Create Ticket API implementation.
+- Attachment removal is always soft removal; the database record and metadata are retained.

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -31,15 +31,16 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 | RESPONSIVE-01 | Responsive | AC-09 | Responsive layouts | Checks desktop, tablet, and mobile screenshots for clipping or overflow | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
 | E2E-01 | End-to-end | AC-02, AC-05, AC-06 | Requester ticket flow | Requester A creates and finds a ticket; Requester B cannot access it | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
 | E2E-02 | End-to-end | AC-07, AC-08 | Attachment lifecycle | Owner uploads and soft-removes an attachment; removed file cannot download | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
+| DB-01 | Database Integration | Data Changes, AC-01, AC-04 | Lab 2 schema and idempotent seed data | Required categories, seven related systems, four active requesters, and one inactive requester exist without duplicates | `server/tests/lab-02/data-model.test.ts` | Passed |
 
 ## 3. Acceptance-Criterion Traceability
 
 | Acceptance Criterion | Planned Tests | Evidence Required |
 | --- | --- | --- |
-| AC-01 — Development Requester Selection | API-01, UI-01 | API result and requester selector screenshot |
+| AC-01 — Development Requester Selection | DB-01, API-01, UI-01 | Seed-data test, API result, and requester selector screenshot |
 | AC-02 — Create Valid Ticket | UNIT-01, API-02, E2E-01 | Passing test output and created ticket screenshot |
 | AC-03 — Ticket Validation | API-03, UI-02 | Passing tests and validation-message screenshot |
-| AC-04 — Active Reference Validation | API-04 | Passing API test output |
+| AC-04 — Active Reference Validation | DB-01, API-04 | Seed-data test and passing API test output |
 | AC-05 — Requester-Owned Ticket List | API-05, UI-03, E2E-01 | My Tickets screenshot with search, filters, sorting, and pagination |
 | AC-06 — Ownership Protection | API-06, E2E-01 | Passing API test and cross-requester access evidence |
 | AC-07 — Upload Attachment | API-07, E2E-02 | Passing test and uploaded attachment screenshot |

--- a/server/prisma/migrations/20260904093633_lab2_data_model/migration.sql
+++ b/server/prisma/migrations/20260904093633_lab2_data_model/migration.sql
@@ -1,0 +1,94 @@
+-- CreateEnum
+CREATE TYPE "Priority" AS ENUM ('LOW', 'MEDIUM', 'HIGH');
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Requester" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Requester_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "summary" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "priority" "Priority" NOT NULL,
+    "currentStatus" TEXT NOT NULL DEFAULT 'New',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "storedFilename" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removedAt" TIMESTAMP(3),
+    "removalReason" TEXT,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Requester_email_key" ON "Requester"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_idx" ON "Ticket"("requesterId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_categoryId_idx" ON "Ticket"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_relatedSystemId_idx" ON "Ticket"("relatedSystemId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_createdAt_idx" ON "Ticket"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_idx" ON "Attachment"("ticketId");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "Requester"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,6 +1,3 @@
-// Prisma schema — datasource and generator are pre-wired.
-// Your DATABASE_URL lives in server/.env (copy it from .env.example).
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -10,12 +7,76 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// ---------------------------------------------------------------------------
-// Issue 3 — Create and seed IT request categories
-// ---------------------------------------------------------------------------
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+}
 
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+model Requester {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+model Ticket {
+  id              Int      @id @default(autoincrement())
+  ticketNumber    String   @unique
+  requesterId     Int
+  categoryId      Int
+  relatedSystemId Int
+  summary         String
+  description     String
+  priority        Priority
+  currentStatus   String   @default("New")
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  requester     Requester     @relation(fields: [requesterId], references: [id])
+  category      Category      @relation(fields: [categoryId], references: [id])
+  relatedSystem RelatedSystem @relation(fields: [relatedSystemId], references: [id])
+  attachments   Attachment[]
+
+  @@index([requesterId])
+  @@index([categoryId])
+  @@index([relatedSystemId])
+  @@index([createdAt])
+}
+
+model Attachment {
+  id               Int       @id @default(autoincrement())
+  ticketId         Int
+  originalFilename String
+  storedFilename   String
+  mimeType         String
+  sizeBytes        Int
+  createdAt        DateTime  @default(now())
+  removedAt        DateTime?
+  removalReason    String?
+
+  ticket Ticket @relation(fields: [ticketId], references: [id])
+
+  @@index([ticketId])
 }

--- a/server/prisma/seed-data.ts
+++ b/server/prisma/seed-data.ts
@@ -1,0 +1,93 @@
+import { PrismaClient } from "@prisma/client";
+
+export const categories = [
+  { name: "Account and Access", isActive: true },
+  { name: "Hardware", isActive: true },
+  { name: "Software", isActive: true },
+  { name: "Network", isActive: true },
+  { name: "Legacy Service", isActive: false },
+];
+
+export const relatedSystems = [
+  { name: "Email", isActive: true },
+  { name: "Campus Wi-Fi", isActive: true },
+  { name: "VPN", isActive: true },
+  { name: "LEB2 App", isActive: true },
+  { name: "Grade Submission App", isActive: true },
+  { name: "Printer", isActive: true },
+  { name: "Corporate Laptop", isActive: true },
+  { name: "Legacy Student Portal", isActive: false },
+];
+
+export const requesters = [
+  {
+    name: "Anan Student",
+    email: "anan.student@toktickit.local",
+    isActive: true,
+  },
+  {
+    name: "Benja Student",
+    email: "benja.student@toktickit.local",
+    isActive: true,
+  },
+  {
+    name: "Chalida Student",
+    email: "chalida.student@toktickit.local",
+    isActive: true,
+  },
+  {
+    name: "Danai Student",
+    email: "danai.student@toktickit.local",
+    isActive: true,
+  },
+  {
+    name: "Inactive Requester",
+    email: "inactive.requester@toktickit.local",
+    isActive: false,
+  },
+];
+
+export async function seedLab2Data(prisma: PrismaClient) {
+  for (const category of categories) {
+    await prisma.category.upsert({
+      where: {
+        name: category.name,
+      },
+      update: {
+        isActive: category.isActive,
+      },
+      create: category,
+    });
+  }
+
+  for (const system of relatedSystems) {
+    await prisma.relatedSystem.upsert({
+      where: {
+        name: system.name,
+      },
+      update: {
+        isActive: system.isActive,
+      },
+      create: system,
+    });
+  }
+
+  for (const requester of requesters) {
+    await prisma.requester.upsert({
+      where: {
+        email: requester.email,
+      },
+      update: {
+        name: requester.name,
+        isActive: requester.isActive,
+      },
+      create: requester,
+    });
+  }
+
+  return {
+    categoryCount: categories.length,
+    relatedSystemCount: relatedSystems.length,
+    requesterCount: requesters.length,
+  };
+}

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -13,17 +13,83 @@ async function main() {
   for (const name of categories) {
     await prisma.category.upsert({
       where: { name },
-      update: {},
-      create: { name },
+      update: { isActive: true },
+      create: {
+        name,
+        isActive: true,
+      },
     });
   }
 
-  console.log("Category seed completed.");
+  const relatedSystems = [
+    "Email",
+    "Campus Wi-Fi",
+    "VPN",
+    "LEB2 App",
+    "Grade Submission App",
+    "Printer",
+    "Corporate Laptop",
+  ];
+
+  for (const name of relatedSystems) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: { isActive: true },
+      create: {
+        name,
+        isActive: true,
+      },
+    });
+  }
+
+  const requesters = [
+    {
+      name: "Anan Student",
+      email: "anan.student@toktickit.local",
+      isActive: true,
+    },
+    {
+      name: "Benja Student",
+      email: "benja.student@toktickit.local",
+      isActive: true,
+    },
+    {
+      name: "Chalida Student",
+      email: "chalida.student@toktickit.local",
+      isActive: true,
+    },
+    {
+      name: "Danai Student",
+      email: "danai.student@toktickit.local",
+      isActive: true,
+    },
+    {
+      name: "Inactive Requester",
+      email: "inactive.requester@toktickit.local",
+      isActive: false,
+    },
+  ];
+
+  for (const requester of requesters) {
+    await prisma.requester.upsert({
+      where: { email: requester.email },
+      update: {
+        name: requester.name,
+        isActive: requester.isActive,
+      },
+      create: requester,
+    });
+  }
+
+  console.log("Lab 2 seed completed.");
+  console.log(`Categories: ${categories.length}`);
+  console.log(`Related systems: ${relatedSystems.length}`);
+  console.log(`Requesters: ${requesters.length}`);
 }
 
 main()
-  .catch((e) => {
-    console.error(e);
+  .catch((error) => {
+    console.error("Lab 2 seed failed:", error);
     process.exit(1);
   })
   .finally(async () => {

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,96 +1,20 @@
 import { getPrisma } from "../src/prisma.js";
+import { seedLab2Data } from "./seed-data.js";
 
 async function main() {
   const prisma = getPrisma();
-
-  const categories = [
-    "Account and Access",
-    "Hardware",
-    "Software",
-    "Network",
-  ];
-
-  for (const name of categories) {
-    await prisma.category.upsert({
-      where: { name },
-      update: { isActive: true },
-      create: {
-        name,
-        isActive: true,
-      },
-    });
-  }
-
-  const relatedSystems = [
-    "Email",
-    "Campus Wi-Fi",
-    "VPN",
-    "LEB2 App",
-    "Grade Submission App",
-    "Printer",
-    "Corporate Laptop",
-  ];
-
-  for (const name of relatedSystems) {
-    await prisma.relatedSystem.upsert({
-      where: { name },
-      update: { isActive: true },
-      create: {
-        name,
-        isActive: true,
-      },
-    });
-  }
-
-  const requesters = [
-    {
-      name: "Anan Student",
-      email: "anan.student@toktickit.local",
-      isActive: true,
-    },
-    {
-      name: "Benja Student",
-      email: "benja.student@toktickit.local",
-      isActive: true,
-    },
-    {
-      name: "Chalida Student",
-      email: "chalida.student@toktickit.local",
-      isActive: true,
-    },
-    {
-      name: "Danai Student",
-      email: "danai.student@toktickit.local",
-      isActive: true,
-    },
-    {
-      name: "Inactive Requester",
-      email: "inactive.requester@toktickit.local",
-      isActive: false,
-    },
-  ];
-
-  for (const requester of requesters) {
-    await prisma.requester.upsert({
-      where: { email: requester.email },
-      update: {
-        name: requester.name,
-        isActive: requester.isActive,
-      },
-      create: requester,
-    });
-  }
+  const result = await seedLab2Data(prisma);
 
   console.log("Lab 2 seed completed.");
-  console.log(`Categories: ${categories.length}`);
-  console.log(`Related systems: ${relatedSystems.length}`);
-  console.log(`Requesters: ${requesters.length}`);
+  console.log(`Categories: ${result.categoryCount}`);
+  console.log(`Related systems: ${result.relatedSystemCount}`);
+  console.log(`Requesters: ${result.requesterCount}`);
 }
 
 main()
   .catch((error) => {
     console.error("Lab 2 seed failed:", error);
-    process.exit(1);
+    process.exitCode = 1;
   })
   .finally(async () => {
     await getPrisma().$disconnect();

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -15,12 +15,15 @@ app.get("/api/health", (_req: Request, res: Response) => {
   });
 });
 
-// Issue 4 - Category list
+// Issue 4 - Active category list
 app.get("/api/categories", async (_req: Request, res: Response) => {
   try {
     const prisma = getPrisma();
 
     const categories = await prisma.category.findMany({
+      where: {
+        isActive: true,
+      },
       select: {
         id: true,
         name: true,

--- a/server/tests/lab-02/data-model.test.ts
+++ b/server/tests/lab-02/data-model.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { getPrisma } from "../../src/prisma.js";
+
+const prisma = getPrisma();
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("Lab 2 data model and seed data", () => {
+  it("contains the four required active categories", async () => {
+    const requiredNames = [
+      "Account and Access",
+      "Hardware",
+      "Software",
+      "Network",
+    ];
+
+    const categories = await prisma.category.findMany({
+      where: {
+        name: {
+          in: requiredNames,
+        },
+      },
+      select: {
+        name: true,
+        isActive: true,
+      },
+    });
+
+    expect(categories).toHaveLength(4);
+    expect(categories.every((category) => category.isActive)).toBe(true);
+    expect(categories.map((category) => category.name).sort()).toEqual(
+      [...requiredNames].sort(),
+    );
+  });
+
+  it("contains at least six active related systems", async () => {
+    const seededNames = [
+      "Email",
+      "Campus Wi-Fi",
+      "VPN",
+      "LEB2 App",
+      "Grade Submission App",
+      "Printer",
+      "Corporate Laptop",
+    ];
+
+    const relatedSystems = await prisma.relatedSystem.findMany({
+      where: {
+        name: {
+          in: seededNames,
+        },
+      },
+      select: {
+        name: true,
+        isActive: true,
+      },
+    });
+
+    expect(relatedSystems).toHaveLength(7);
+    expect(relatedSystems.every((system) => system.isActive)).toBe(true);
+    expect(new Set(relatedSystems.map((system) => system.name)).size).toBe(7);
+  });
+
+  it("contains four active and one inactive development requester", async () => {
+    const seededEmails = [
+      "anan.student@toktickit.local",
+      "benja.student@toktickit.local",
+      "chalida.student@toktickit.local",
+      "danai.student@toktickit.local",
+      "inactive.requester@toktickit.local",
+    ];
+
+    const requesters = await prisma.requester.findMany({
+      where: {
+        email: {
+          in: seededEmails,
+        },
+      },
+      select: {
+        email: true,
+        isActive: true,
+      },
+    });
+
+    const activeRequesters = requesters.filter(
+      (requester) => requester.isActive,
+    );
+    const inactiveRequesters = requesters.filter(
+      (requester) => !requester.isActive,
+    );
+
+    expect(requesters).toHaveLength(5);
+    expect(activeRequesters).toHaveLength(4);
+    expect(inactiveRequesters).toHaveLength(1);
+    expect(new Set(requesters.map((requester) => requester.email)).size).toBe(5);
+  });
+});

--- a/server/tests/lab-02/data-model.test.ts
+++ b/server/tests/lab-02/data-model.test.ts
@@ -1,7 +1,25 @@
 import { afterAll, describe, expect, it } from "vitest";
+import {
+  categories,
+  relatedSystems,
+  requesters,
+  seedLab2Data,
+} from "../../prisma/seed-data.js";
 import { getPrisma } from "../../src/prisma.js";
 
 const prisma = getPrisma();
+
+const activeCategoryNames = categories
+  .filter((category) => category.isActive)
+  .map((category) => category.name);
+
+const activeRelatedSystemNames = relatedSystems
+  .filter((system) => system.isActive)
+  .map((system) => system.name);
+
+const seededRequesterEmails = requesters.map(
+  (requester) => requester.email,
+);
 
 afterAll(async () => {
   await prisma.$disconnect();
@@ -9,17 +27,10 @@ afterAll(async () => {
 
 describe("Lab 2 data model and seed data", () => {
   it("contains the four required active categories", async () => {
-    const requiredNames = [
-      "Account and Access",
-      "Hardware",
-      "Software",
-      "Network",
-    ];
-
-    const categories = await prisma.category.findMany({
+    const seededCategories = await prisma.category.findMany({
       where: {
         name: {
-          in: requiredNames,
+          in: activeCategoryNames,
         },
       },
       select: {
@@ -28,28 +39,21 @@ describe("Lab 2 data model and seed data", () => {
       },
     });
 
-    expect(categories).toHaveLength(4);
-    expect(categories.every((category) => category.isActive)).toBe(true);
-    expect(categories.map((category) => category.name).sort()).toEqual(
-      [...requiredNames].sort(),
-    );
+    expect(seededCategories).toHaveLength(4);
+    expect(
+      seededCategories.every((category) => category.isActive),
+    ).toBe(true);
+
+    expect(
+      seededCategories.map((category) => category.name).sort(),
+    ).toEqual([...activeCategoryNames].sort());
   });
 
   it("contains at least six active related systems", async () => {
-    const seededNames = [
-      "Email",
-      "Campus Wi-Fi",
-      "VPN",
-      "LEB2 App",
-      "Grade Submission App",
-      "Printer",
-      "Corporate Laptop",
-    ];
-
-    const relatedSystems = await prisma.relatedSystem.findMany({
+    const seededSystems = await prisma.relatedSystem.findMany({
       where: {
         name: {
-          in: seededNames,
+          in: activeRelatedSystemNames,
         },
       },
       select: {
@@ -58,24 +62,20 @@ describe("Lab 2 data model and seed data", () => {
       },
     });
 
-    expect(relatedSystems).toHaveLength(7);
-    expect(relatedSystems.every((system) => system.isActive)).toBe(true);
-    expect(new Set(relatedSystems.map((system) => system.name)).size).toBe(7);
+    expect(seededSystems).toHaveLength(7);
+    expect(seededSystems.length).toBeGreaterThanOrEqual(6);
+    expect(seededSystems.every((system) => system.isActive)).toBe(true);
+
+    expect(
+      new Set(seededSystems.map((system) => system.name)).size,
+    ).toBe(7);
   });
 
   it("contains four active and one inactive development requester", async () => {
-    const seededEmails = [
-      "anan.student@toktickit.local",
-      "benja.student@toktickit.local",
-      "chalida.student@toktickit.local",
-      "danai.student@toktickit.local",
-      "inactive.requester@toktickit.local",
-    ];
-
-    const requesters = await prisma.requester.findMany({
+    const seededRequesters = await prisma.requester.findMany({
       where: {
         email: {
-          in: seededEmails,
+          in: seededRequesterEmails,
         },
       },
       select: {
@@ -84,16 +84,74 @@ describe("Lab 2 data model and seed data", () => {
       },
     });
 
-    const activeRequesters = requesters.filter(
+    const activeRequesters = seededRequesters.filter(
       (requester) => requester.isActive,
     );
-    const inactiveRequesters = requesters.filter(
+
+    const inactiveRequesters = seededRequesters.filter(
       (requester) => !requester.isActive,
     );
 
-    expect(requesters).toHaveLength(5);
+    expect(seededRequesters).toHaveLength(5);
     expect(activeRequesters).toHaveLength(4);
     expect(inactiveRequesters).toHaveLength(1);
-    expect(new Set(requesters.map((requester) => requester.email)).size).toBe(5);
+
+    expect(
+      new Set(seededRequesters.map((requester) => requester.email)).size,
+    ).toBe(5);
+  });
+
+  it("contains inactive category and related system fixtures", async () => {
+    const inactiveCategory = await prisma.category.findUnique({
+      where: {
+        name: "Legacy Service",
+      },
+    });
+
+    const inactiveRelatedSystem =
+      await prisma.relatedSystem.findUnique({
+        where: {
+          name: "Legacy Student Portal",
+        },
+      });
+
+    expect(inactiveCategory).not.toBeNull();
+    expect(inactiveCategory?.isActive).toBe(false);
+
+    expect(inactiveRelatedSystem).not.toBeNull();
+    expect(inactiveRelatedSystem?.isActive).toBe(false);
+  });
+
+  it("can run the seed twice without creating duplicate data", async () => {
+    await seedLab2Data(prisma);
+    await seedLab2Data(prisma);
+
+    const categoryCount = await prisma.category.count({
+      where: {
+        name: {
+          in: categories.map((category) => category.name),
+        },
+      },
+    });
+
+    const relatedSystemCount = await prisma.relatedSystem.count({
+      where: {
+        name: {
+          in: relatedSystems.map((system) => system.name),
+        },
+      },
+    });
+
+    const requesterCount = await prisma.requester.count({
+      where: {
+        email: {
+          in: seededRequesterEmails,
+        },
+      },
+    });
+
+    expect(categoryCount).toBe(categories.length);
+    expect(relatedSystemCount).toBe(relatedSystems.length);
+    expect(requesterCount).toBe(requesters.length);
   });
 });


### PR DESCRIPTION
## Summary

- Added the Lab 2 database models for requesters, related systems, tickets, and attachments.
- Added `isActive` to categories and added the `Priority` enum.
- Added database relationships, unique constraints, indexes, timestamps, and soft-removal fields for attachments.
- Added seed data for four categories, seven related systems, four active requesters, and one inactive requester.
- Added database tests and updated the Lab 2 test and review documents.

## Testing

- Ran the seed twice successfully without creating duplicates.
- `npm test` — all 5 tests passed.
- `npm run build` — passed.
- The Lab 2 database migration was applied successfully.
<img width="1147" height="220" alt="Screenshot 2026-09-04 170044" src="https://github.com/user-attachments/assets/129139e5-8fc9-487e-9afb-2446d5929de9" />
<img width="970" height="438" alt="image" src="https://github.com/user-attachments/assets/8ac34a51-a1c7-4476-8c4f-baaa701788a9" />
<img width="891" height="250" alt="image" src="https://github.com/user-attachments/assets/99a65041-8683-4669-9411-738eb738808c" />
