### PR TITLE
feat: add Development Requester selection

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,11 +1,48 @@
 import { useState } from "react";
-import { checkSystem, type Category } from "./api.js";
+import {
+  checkSystem,
+  type Category,
+  type Requester,
+} from "./api.js";
+import RequesterSelector from "./RequesterSelector.js";
 
 type UiState = "idle" | "loading" | "success" | "error";
+const REQUESTER_STORAGE_KEY = "toktickit.developmentRequester";
+
+function loadSavedRequester(): Requester | null {
+  const saved = localStorage.getItem(REQUESTER_STORAGE_KEY);
+
+  if (!saved) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(saved) as Requester;
+  } catch {
+    localStorage.removeItem(REQUESTER_STORAGE_KEY);
+    return null;
+  }
+}
 
 export default function App() {
   const [state, setState] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
+  const [requester, setRequester] = useState<Requester | null>(
+    loadSavedRequester
+  );
+
+  function handleRequesterSelect(selectedRequester: Requester) {
+    localStorage.setItem(
+      REQUESTER_STORAGE_KEY,
+      JSON.stringify(selectedRequester)
+    );
+    setRequester(selectedRequester);
+  }
+
+  function handleRequesterChange() {
+    localStorage.removeItem(REQUESTER_STORAGE_KEY);
+    setRequester(null);
+  }
 
   async function handleCheck() {
     setState("loading");
@@ -22,48 +59,106 @@ export default function App() {
   }
 
   return (
-    <div className="container py-5" style={{ maxWidth: 640 }}>
-      <h1 className="h3 mb-4">
-        TokTickIT <span className="text-success">IT Service Desk</span>
-      </h1>
+    <div className="app-shell min-vh-100">
+      <header className="topbar">
+        <div className="container d-flex align-items-center justify-content-between gap-3">
+          <a className="brand" href="#" aria-label="TokTickIT home">
+            <span className="brand__mark">T</span>
+            <span>TokTickIT</span>
+          </a>
 
-      <button
-        className="btn btn-success"
-        onClick={handleCheck}
-        disabled={state === "loading"}
-      >
-        {state === "loading" ? "Loading..." : "Check System"}
-      </button>
-
-      {state === "loading" && (
-        <p className="mt-3">Checking the system...</p>
-      )}
-
-      {state === "success" && (
-        <div className="mt-3">
-          <p>
-            System Status:{" "}
-            <strong className="text-success">Online</strong>
-          </p>
-
-          <h2 className="h5">Supported Request Categories:</h2>
-
-          <ol>
-            {categories.map((category) => (
-              <li key={category.id}>{category.name}</li>
-            ))}
-          </ol>
+          {requester && (
+            <div className="requester-chip">
+              <span className="requester-chip__avatar" aria-hidden="true">
+                {requester.name.charAt(0)}
+              </span>
+              <span>
+                <small>Current requester</small>
+                <strong>{requester.name}</strong>
+              </span>
+            </div>
+          )}
         </div>
-      )}
+      </header>
 
-      {state === "error" && (
-        <div className="mt-3 text-danger">
-          <strong>System Status: Offline</strong>
-          <p className="mb-0">
-            Unable to connect to TokTickIT API.
+      <main className="container py-5 page-content">
+        <div className="hero-copy text-center mx-auto mb-4">
+          <p className="eyebrow mb-2">IT support, made simple</p>
+          <h1 className="display-6 fw-bold mb-3">
+            TokTickIT <span>IT Service Desk</span>
+          </h1>
+          <p className="lead text-secondary mb-0">
+            Select a development identity to create and follow your support tickets.
           </p>
         </div>
-      )}
+
+        {!requester ? (
+          <RequesterSelector onSelect={handleRequesterSelect} />
+        ) : (
+          <section className="selected-card" aria-labelledby="selected-heading">
+            <div>
+              <p className="eyebrow mb-2">Ready to continue</p>
+              <h2 id="selected-heading" className="h3 mb-2">
+                Welcome, {requester.name}
+              </h2>
+              <p className="text-secondary mb-1">{requester.email}</p>
+              <p className="mb-0">
+                Your requester identity is active for this browser.
+              </p>
+            </div>
+            <button
+              className="btn btn-outline-zen"
+              onClick={handleRequesterChange}
+            >
+              Change requester
+            </button>
+          </section>
+        )}
+
+        <section className="system-card mt-4" aria-labelledby="system-heading">
+          <div className="d-flex flex-wrap align-items-center justify-content-between gap-3">
+            <div>
+              <p className="eyebrow mb-1">Development diagnostics</p>
+              <h2 id="system-heading" className="h5 mb-0">System connection</h2>
+            </div>
+            <button
+              className="btn btn-outline-zen"
+              onClick={handleCheck}
+              disabled={state === "loading"}
+            >
+              {state === "loading" ? "Loading..." : "Check System"}
+            </button>
+          </div>
+
+          {state === "loading" && (
+            <p className="mt-3 mb-0">Checking the system...</p>
+          )}
+
+          {state === "success" && (
+            <div className="mt-3">
+              <p>
+                System Status:{" "}
+                <strong className="text-success">Online</strong>
+              </p>
+
+              <h3 className="h6">Supported Request Categories:</h3>
+
+              <ol className="mb-0">
+                {categories.map((category) => (
+                  <li key={category.id}>{category.name}</li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          {state === "error" && (
+            <div className="mt-3 text-danger">
+              <strong>System Status: Offline</strong>
+              <p className="mb-0">Unable to connect to TokTickIT API.</p>
+            </div>
+          )}
+        </section>
+      </main>
     </div>
   );
 }

--- a/client/src/RequesterSelector.tsx
+++ b/client/src/RequesterSelector.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { getRequesters, type Requester } from "./api.js";
+
+interface RequesterSelectorProps {
+  onSelect: (requester: Requester) => void;
+}
+
+type LoadState = "loading" | "success" | "error";
+
+export default function RequesterSelector({ onSelect }: RequesterSelectorProps) {
+  const [requesters, setRequesters] = useState<Requester[]>([]);
+  const [selectedId, setSelectedId] = useState("");
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+
+  async function loadRequesters() {
+    setLoadState("loading");
+
+    try {
+      const result = await getRequesters();
+      setRequesters(result);
+      setLoadState("success");
+    } catch {
+      setRequesters([]);
+      setLoadState("error");
+    }
+  }
+
+  useEffect(() => {
+    void loadRequesters();
+  }, []);
+
+  function handleContinue() {
+    const requester = requesters.find(
+      (item) => item.id === Number(selectedId)
+    );
+
+    if (requester) {
+      onSelect(requester);
+    }
+  }
+
+  return (
+    <section className="requester-card" aria-labelledby="requester-heading">
+      <div className="requester-card__icon" aria-hidden="true">
+        <span>DR</span>
+      </div>
+
+      <p className="eyebrow mb-2">Development mode</p>
+      <h2 id="requester-heading" className="h3 mb-2">
+        Select a Development Requester
+      </h2>
+      <p className="text-secondary mb-4">
+        Choose a test identity before using requester-specific ticket features.
+        This selector is not a real login.
+      </p>
+
+      {loadState === "loading" && (
+        <div className="state-panel" role="status">
+          <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+          Loading requesters...
+        </div>
+      )}
+
+      {loadState === "error" && (
+        <div className="state-panel state-panel--error" role="alert">
+          <div>
+            <strong>Requester list unavailable</strong>
+            <p className="mb-0">Check the API connection and try again.</p>
+          </div>
+          <button className="btn btn-outline-danger" onClick={loadRequesters}>
+            Try again
+          </button>
+        </div>
+      )}
+
+      {loadState === "success" && requesters.length === 0 && (
+        <div className="state-panel" role="status">
+          No active Development Requesters are available.
+        </div>
+      )}
+
+      {loadState === "success" && requesters.length > 0 && (
+        <div className="text-start">
+          <label className="form-label fw-semibold" htmlFor="requester">
+            Requester <span className="text-danger">*</span>
+          </label>
+          <select
+            id="requester"
+            className="form-select form-select-lg"
+            value={selectedId}
+            onChange={(event) => setSelectedId(event.target.value)}
+          >
+            <option value="">Choose a requester</option>
+            {requesters.map((requester) => (
+              <option key={requester.id} value={requester.id}>
+                {requester.name} - {requester.email}
+              </option>
+            ))}
+          </select>
+          <p className="form-text">
+            Only active requester profiles are shown.
+          </p>
+
+          <button
+            className="btn btn-zen btn-lg w-100 mt-3"
+            disabled={!selectedId}
+            onClick={handleContinue}
+          >
+            Continue as requester
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -5,6 +5,12 @@ export interface Category {
   name: string;
 }
 
+export interface Requester {
+  id: number;
+  name: string;
+  email: string;
+}
+
 export interface SystemStatus {
   online: boolean;
   categories: Category[];
@@ -39,4 +45,14 @@ export async function checkSystem(): Promise<SystemStatus> {
     online: true,
     categories,
   };
+}
+
+export async function getRequesters(): Promise<Requester[]> {
+  const response = await fetch(`${API_URL}/api/requesters`);
+
+  if (!response.ok) {
+    throw new Error("Unable to load development requesters");
+  }
+
+  return response.json();
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "bootstrap/dist/css/bootstrap.min.css";
+import "./styles.css";
 import App from "./App.js";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,6 +1,14 @@
 :root {
-  color: #17352d;
-  background: #f5f3ed;
+  --zen-primary: #006B3C;
+  --zen-secondary: #0B7A46;
+  --zen-pale: #EAF6EF;
+  --zen-page: #F5F7F6;
+  --zen-text: #17352d;
+  --zen-muted: #60736b;
+  --zen-border: #cfe0d7;
+
+  color: var(--zen-text);
+  background: var(--zen-page);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
 }
@@ -9,18 +17,19 @@ body {
   min-width: 320px;
   margin: 0;
   background:
-    radial-gradient(circle at 10% 5%, rgba(84, 148, 115, 0.14), transparent 28rem),
-    #f5f3ed;
+    radial-gradient(circle at 10% 5%, rgba(11, 122, 70, 0.12), transparent 28rem),
+    var(--zen-page);
 }
 
 .app-shell {
-  color: #17352d;
+  color: var(--zen-text);
 }
 
 .topbar {
   padding: 0.9rem 0;
-  border-bottom: 1px solid rgba(31, 79, 64, 0.14);
-  background: rgba(255, 255, 255, 0.86);
+  border-bottom: 1px solid var(--zen-secondary);
+  color: #fff;
+  background: var(--zen-primary);
   backdrop-filter: blur(16px);
 }
 
@@ -28,7 +37,7 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.7rem;
-  color: #17352d;
+  color: #fff;
   font-size: 1.15rem;
   font-weight: 800;
   text-decoration: none;
@@ -41,9 +50,13 @@ body {
   width: 2.25rem;
   height: 2.25rem;
   border-radius: 0.75rem;
-  color: #fff;
-  background: #245f4d;
-  box-shadow: 0 7px 18px rgba(36, 95, 77, 0.22);
+  color: var(--zen-primary);
+  background: var(--zen-pale);
+  box-shadow: 0 7px 18px rgba(0, 49, 28, 0.22);
+}
+
+.topbar .requester-chip small {
+  color: rgba(255, 255, 255, 0.78);
 }
 
 .page-content {
@@ -56,7 +69,7 @@ body {
 
 .hero-copy h1 span,
 .eyebrow {
-  color: #287458;
+  color: var(--zen-secondary);
 }
 
 .eyebrow {
@@ -69,7 +82,7 @@ body {
 .requester-card,
 .selected-card,
 .system-card {
-  border: 1px solid rgba(31, 79, 64, 0.13);
+  border: 1px solid var(--zen-border);
   border-radius: 1.35rem;
   background: rgba(255, 255, 255, 0.94);
   box-shadow: 0 18px 55px rgba(25, 64, 52, 0.09);
@@ -90,27 +103,27 @@ body {
   margin: 0 auto 1.15rem;
   border-radius: 1.25rem;
   color: #fff;
-  background: linear-gradient(145deg, #1e604a, #4e9a73);
+  background: linear-gradient(145deg, var(--zen-primary), var(--zen-secondary));
   font-weight: 800;
   letter-spacing: 0.06em;
 }
 
 .form-select:focus {
-  border-color: #398564;
-  box-shadow: 0 0 0 0.25rem rgba(57, 133, 100, 0.18);
+  border-color: var(--zen-secondary);
+  box-shadow: 0 0 0 0.25rem rgba(11, 122, 70, 0.18);
 }
 
 .btn-zen {
   color: #fff;
-  border-color: #245f4d;
-  background: #245f4d;
+  border-color: var(--zen-primary);
+  background: var(--zen-primary);
 }
 
 .btn-zen:hover,
 .btn-zen:focus-visible {
   color: #fff;
-  border-color: #194638;
-  background: #194638;
+  border-color: var(--zen-secondary);
+  background: var(--zen-secondary);
 }
 
 .btn-zen:disabled {
@@ -120,16 +133,16 @@ body {
 }
 
 .btn-outline-zen {
-  color: #245f4d;
-  border: 1px solid #5f8d7b;
+  color: var(--zen-primary);
+  border: 1px solid var(--zen-secondary);
   background: #fff;
 }
 
 .btn-outline-zen:hover,
 .btn-outline-zen:focus-visible {
   color: #fff;
-  border-color: #245f4d;
-  background: #245f4d;
+  border-color: var(--zen-secondary);
+  background: var(--zen-secondary);
 }
 
 .selected-card,
@@ -142,7 +155,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-  border-left: 5px solid #3b8a67;
+  border-left: 5px solid var(--zen-secondary);
 }
 
 .requester-chip {
@@ -157,7 +170,7 @@ body {
 }
 
 .requester-chip small {
-  color: #718079;
+  color: var(--zen-muted);
   font-size: 0.72rem;
 }
 
@@ -171,9 +184,13 @@ body {
   justify-content: center;
   gap: 0.75rem;
   padding: 1rem;
-  border: 1px solid #d8e4de;
+  border: 1px solid var(--zen-border);
   border-radius: 0.9rem;
-  background: #f2f8f5;
+  background: var(--zen-pale);
+}
+
+.text-success {
+  color: var(--zen-secondary) !important;
 }
 
 .state-panel--error {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,0 +1,207 @@
+:root {
+  color: #17352d;
+  background: #f5f3ed;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+}
+
+body {
+  min-width: 320px;
+  margin: 0;
+  background:
+    radial-gradient(circle at 10% 5%, rgba(84, 148, 115, 0.14), transparent 28rem),
+    #f5f3ed;
+}
+
+.app-shell {
+  color: #17352d;
+}
+
+.topbar {
+  padding: 0.9rem 0;
+  border-bottom: 1px solid rgba(31, 79, 64, 0.14);
+  background: rgba(255, 255, 255, 0.86);
+  backdrop-filter: blur(16px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  color: #17352d;
+  font-size: 1.15rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.brand__mark,
+.requester-chip__avatar {
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  color: #fff;
+  background: #245f4d;
+  box-shadow: 0 7px 18px rgba(36, 95, 77, 0.22);
+}
+
+.page-content {
+  max-width: 800px;
+}
+
+.hero-copy {
+  max-width: 650px;
+}
+
+.hero-copy h1 span,
+.eyebrow {
+  color: #287458;
+}
+
+.eyebrow {
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.requester-card,
+.selected-card,
+.system-card {
+  border: 1px solid rgba(31, 79, 64, 0.13);
+  border-radius: 1.35rem;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 18px 55px rgba(25, 64, 52, 0.09);
+}
+
+.requester-card {
+  max-width: 590px;
+  margin: 0 auto;
+  padding: clamp(1.5rem, 5vw, 2.6rem);
+  text-align: center;
+}
+
+.requester-card__icon {
+  display: grid;
+  place-items: center;
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto 1.15rem;
+  border-radius: 1.25rem;
+  color: #fff;
+  background: linear-gradient(145deg, #1e604a, #4e9a73);
+  font-weight: 800;
+  letter-spacing: 0.06em;
+}
+
+.form-select:focus {
+  border-color: #398564;
+  box-shadow: 0 0 0 0.25rem rgba(57, 133, 100, 0.18);
+}
+
+.btn-zen {
+  color: #fff;
+  border-color: #245f4d;
+  background: #245f4d;
+}
+
+.btn-zen:hover,
+.btn-zen:focus-visible {
+  color: #fff;
+  border-color: #194638;
+  background: #194638;
+}
+
+.btn-zen:disabled {
+  color: #fff;
+  border-color: #8ca99e;
+  background: #8ca99e;
+}
+
+.btn-outline-zen {
+  color: #245f4d;
+  border: 1px solid #5f8d7b;
+  background: #fff;
+}
+
+.btn-outline-zen:hover,
+.btn-outline-zen:focus-visible {
+  color: #fff;
+  border-color: #245f4d;
+  background: #245f4d;
+}
+
+.selected-card,
+.system-card {
+  padding: clamp(1.25rem, 4vw, 2rem);
+}
+
+.selected-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-left: 5px solid #3b8a67;
+}
+
+.requester-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.requester-chip small,
+.requester-chip strong {
+  display: block;
+}
+
+.requester-chip small {
+  color: #718079;
+  font-size: 0.72rem;
+}
+
+.requester-chip strong {
+  font-size: 0.9rem;
+}
+
+.state-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid #d8e4de;
+  border-radius: 0.9rem;
+  background: #f2f8f5;
+}
+
+.state-panel--error {
+  justify-content: space-between;
+  color: #842029;
+  border-color: #f1b8bd;
+  background: #fff5f5;
+  text-align: left;
+}
+
+@media (max-width: 767.98px) {
+  .topbar {
+    padding: 0.75rem 0;
+  }
+
+  .requester-chip small,
+  .requester-chip__avatar {
+    display: none;
+  }
+
+  .selected-card,
+  .state-panel--error {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .selected-card .btn,
+  .state-panel--error .btn {
+    width: 100%;
+  }
+}

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -6,11 +6,17 @@ import * as api from "../../src/api.js";
 describe("App", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    localStorage.clear();
   });
 
   it("renders the TokTickIT heading", () => {
     render(<App />);
-    expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /TokTickIT IT Service Desk/i,
+      })
+    ).toBeInTheDocument();
   });
 
   it("shows Online and the seeded categories on success", async () => {

--- a/client/tests/lab-02/RequesterSelector.test.tsx
+++ b/client/tests/lab-02/RequesterSelector.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import RequesterSelector from "../../src/RequesterSelector.js";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+const activeRequesters: api.Requester[] = [
+  {
+    id: 1,
+    name: "Anan Student",
+    email: "anan.student@toktickit.local",
+  },
+  {
+    id: 2,
+    name: "Benja Student",
+    email: "benja.student@toktickit.local",
+  },
+];
+
+describe("Development Requester selector", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("loads active requesters and requires a selection", async () => {
+    vi.spyOn(api, "getRequesters").mockResolvedValue(activeRequesters);
+
+    render(<RequesterSelector onSelect={vi.fn()} />);
+
+    expect(screen.getByText(/Loading requesters/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Anan Student/)).toBeInTheDocument();
+    expect(screen.getByText(/Benja Student/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Continue as requester/i })
+    ).toBeDisabled();
+  });
+
+  it("returns the selected requester when Continue is clicked", async () => {
+    const onSelect = vi.fn();
+    vi.spyOn(api, "getRequesters").mockResolvedValue(activeRequesters);
+
+    render(<RequesterSelector onSelect={onSelect} />);
+
+    const select = await screen.findByRole("combobox", {
+      name: /Requester/i,
+    });
+    fireEvent.change(select, { target: { value: "2" } });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue as requester/i })
+    );
+
+    expect(onSelect).toHaveBeenCalledWith(activeRequesters[1]);
+  });
+
+  it("keeps the selected requester until the user changes it", async () => {
+    vi.spyOn(api, "getRequesters").mockResolvedValue(activeRequesters);
+
+    const view = render(<App />);
+
+    fireEvent.change(await screen.findByRole("combobox", {
+      name: /Requester/i,
+    }), {
+      target: { value: "1" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Continue as requester/i })
+    );
+
+    expect(screen.getByText(/Welcome, Anan Student/i)).toBeInTheDocument();
+    expect(
+      JSON.parse(localStorage.getItem("toktickit.developmentRequester") ?? "{}")
+    ).toEqual(activeRequesters[0]);
+
+    view.unmount();
+    render(<App />);
+
+    expect(screen.getByText(/Welcome, Anan Student/i)).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Change requester/i })
+    );
+    expect(localStorage.getItem("toktickit.developmentRequester")).toBeNull();
+    expect(
+      await screen.findByText(/Select a Development Requester/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows a useful error when the API is unavailable", async () => {
+    vi.spyOn(api, "getRequesters").mockRejectedValue(
+      new Error("API unavailable")
+    );
+
+    render(<RequesterSelector onSelect={vi.fn()} />);
+
+    expect(
+      await screen.findByText(/Requester list unavailable/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Try again/i })).toBeInTheDocument();
+  });
+});

--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -60,6 +60,20 @@ AI suggested a consistent API structure and safe error responses.
 
 I decided that the selected development requester ID will be sent as `X-Requester-Id` during local testing. I will verify this design against the provided starter code and automated tests before implementing the backend.
 
+## Record 4 — Development Requester Selection
+
+### Prompt
+
+> Help me implement Issue #13 according to the Lab 2 specification. Add an API that returns only active Development Requesters, build a separate requester-selection screen, remember the selected requester, support changing requester, keep the Lab 1 behaviour working, use the Zen Green visual style, and add backend and frontend tests.
+
+### How AI Helped
+
+AI helped draft the API route, React requester selector, loading and error states, local storage behaviour, responsive styling, and automated tests. It also helped diagnose tests that selected ambiguous elements after the UI gained additional headings and labels.
+
+### My Own Decision and Verification
+
+I kept requester selection separate from ticket creation because Lab 2 uses the selected requester as a temporary development identity. I verified that the API excludes inactive requesters, the selected requester remains active after a page reload, and the user can clear it with **Change requester**. I ran the backend and frontend tests and both production builds before preparing the pull request.
+
 ## Reflection
 
 AI was useful for explaining unfamiliar concepts and organizing my work. However, I still need to understand the code, test every feature, read reviewer comments, and make the final implementation decisions myself.

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -22,8 +22,8 @@ For each Lab 2 feature:
 | Issue | Feature branch | Pull request | Reviewer | Result |
 | --- | --- | --- | --- | --- |
 | #11 | `feature/11-lab2-contract` | [PR #19](https://github.com/Thanwarat1303/toktickit/pull/19) | mxckiexz | Approved and merged |
-| #12 | `feature/12-data-seed` | To be added | mxckiexz | In progress |
-| #13 | `feature/13-requester-selection` | To be added | To be added | Not started |
+| #12 | `feature/12-data-seed` | [PR #20](https://github.com/Thanwarat1303/toktickit/pull/20) | mxckiexz | Approved and merged |
+| #13 | `feature/13-requester-selection` | To be added | mxckiexz | Implementation complete; awaiting PR |
 | #14 | `feature/14-create-ticket-api` | To be added | To be added | Not started |
 | #15 | `feature/15-create-ticket-ui` | To be added | To be added | Not started |
 | #16 | `feature/16-my-tickets` | To be added | To be added | Not started |

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -50,6 +50,22 @@ Resolution:
 
 > Changes completed. The reviewer approved the updated pull request, and PR #19 was merged into `lab2-staging`.
 
+### Issue #13 — Development Requester Selection
+
+Reviewer: mxckiexz
+
+Reviewer comment:
+
+> The colors in `client/src/styles.css` did not match the required Zen Green tokens documented in `ui-spec.md`: primary `#006B3C`, secondary `#0B7A46`, pale `#EAF6EF`, and page background `#F5F7F6`.
+
+My response:
+
+> I defined the required Zen Green colors as CSS custom properties and applied them consistently to the page background, header, buttons, accents, focus states, and selected or success states. Neutral, disabled, and error colors are still used for their intended UI states.
+
+Resolution:
+
+> Changes completed. Waiting for the reviewer to re-check the updated pull request.
+
 ## Pull Requests I Reviewed for My Peer
 
 | Peer repository / pull request | What I checked | My review result |

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -15,7 +15,7 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 | Test ID | Type | Requirement / AC | What It Tests | Expected Result | Planned Test File | Status |
 | --- | --- | --- | --- | --- | --- | --- |
 | UNIT-01 | Unit | AC-02 | Ticket number generator | Generates a unique valid ticket number | `server/tests/lab-02/ticket-number.test.ts` | Planned |
-| API-01 | API | AC-01 | Active requester list | Returns active requesters only | `server/tests/lab-02/requesters.api.test.ts` | Planned |
+| API-01 | API | AC-01 | Active requester list | Returns active requesters only | `server/tests/lab-02/requesters.api.test.ts` | Passed |
 | API-02 | API | AC-02 | Valid ticket creation | Creates a ticket with generated number and `New` status | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-03 | API | AC-03 | Required-field validation | Rejects missing or invalid ticket fields with `400` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-04 | API | AC-04 | Active reference validation | Rejects inactive or missing requester, category, and related system | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
@@ -23,7 +23,7 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 | API-06 | API | AC-06 | Ticket ownership | Rejects another requester trying to read ticket detail | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-07 | API | AC-07 | Attachment upload | Accepts allowed files within size and active-count limits | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-08 | API | AC-08 | Attachment soft removal | Stores `removedAt` and removal reason, retains metadata, and blocks download | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| UI-01 | UI Component | AC-01 | Development Requester selector | Displays active requesters and saves the selected requester | `client/tests/lab-02/RequesterSelector.test.tsx` | Planned |
+| UI-01 | UI Component | AC-01 | Development Requester selector | Displays active requesters and saves the selected requester | `client/tests/lab-02/RequesterSelector.test.tsx` | Passed |
 | UI-02 | UI Component | AC-03 | Create Ticket validation | Shows field messages and does not call the API when invalid | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
 | UI-03 | UI Component | AC-05 | My Tickets screen | Displays loading, empty, no-results, and ticket-list states | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-04 | UI Component | AC-08 | Attachment section | Shows active and removed attachment states and confirms removal reason | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
@@ -98,9 +98,15 @@ npx playwright test
 
 ## 6. Final Results
 
-This document was created before implementation.
+Issue #13 verification results:
 
-Test results will be updated after each feature is completed. Final submission evidence must show that all required tests pass and that no required test is skipped, disabled, or commented out.
+- Backend: 4 test files and 9 tests passed.
+- Frontend: 2 test files and 7 tests passed.
+- Backend and frontend TypeScript production builds passed.
+- API-01 verifies that only active requesters are returned in ID order.
+- UI-01 verifies loading, selection, persistence, changing requester, and API failure states.
+
+Final submission evidence must show that all required tests pass and that no required test is skipped, disabled, or commented out.
 
 ## 7. Known Limitations or Deferred Tests
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -41,4 +41,31 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
   }
 });
 
+// Lab 2, Issue 13 - Active Development Requester list
+app.get("/api/requesters", async (_req: Request, res: Response) => {
+  try {
+    const prisma = getPrisma();
+
+    const requesters = await prisma.requester.findMany({
+      where: {
+        isActive: true,
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
+
+    res.status(200).json(requesters);
+  } catch {
+    res.status(500).json({
+      message: "Unable to load development requesters",
+    });
+  }
+});
+
 export default app;

--- a/server/tests/lab-02/requesters.api.test.ts
+++ b/server/tests/lab-02/requesters.api.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+
+describe("GET /api/requesters", () => {
+  it("returns only active Development Requesters in id order", async () => {
+    const prisma = getPrisma();
+    const expectedRequesters = await prisma.requester.findMany({
+      where: {
+        isActive: true,
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
+
+    const response = await request(app).get("/api/requesters");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expectedRequesters);
+    expect(response.body).toHaveLength(4);
+  });
+
+  it("does not expose inactive Development Requesters", async () => {
+    const response = await request(app).get("/api/requesters");
+
+    expect(response.status).toBe(200);
+    expect(response.body).not.toContainEqual(
+      expect.objectContaining({
+        email: "inactive.requester@toktickit.local",
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Added `GET /api/requesters` for loading active Development Requesters.
- Added a separate Development Requester selection screen.
- The selected requester is saved in the browser and remains selected after a page reload.
- Added a `Change requester` button.
- Added loading, empty, and error states.
- Updated the page with the Zen Green style.
- Added backend and frontend tests.

## Testing

- Backend: 9 tests passed.
- Frontend: 7 tests passed.
- Backend and frontend builds passed.
- Manually checked requester selection, page reload persistence, and changing requester.
- Confirmed that inactive requesters are not shown.

## Evidence

- Development Requester selection screen.
- Selected requester screen showing the current requester.

Refs #13