### PR TITLE
feat: add Create Ticket API

### DIFF
--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -74,6 +74,20 @@ AI helped draft the API route, React requester selector, loading and error state
 
 I kept requester selection separate from ticket creation because Lab 2 uses the selected requester as a temporary development identity. I verified that the API excludes inactive requesters, the selected requester remains active after a page reload, and the user can clear it with **Change requester**. I ran the backend and frontend tests and both production builds before preparing the pull request.
 
+## Record 5 — Create Ticket API
+
+### Prompt
+
+> Help me implement the Create Ticket API for Lab 2. It must use the selected development requester in `X-Requester-Id`, validate all ticket fields, reject inactive reference data, create a backend-generated ticket number with status `New`, prevent rapid duplicate submissions, and include API tests.
+
+### How AI Helped
+
+AI helped break the route into validation, reference-data checks, duplicate detection, ticket creation, response formatting, and test cases.
+
+### My Own Decision and Verification
+
+I used the Lab 2 API contract to keep the requester identity in the header rather than the request body. I chose a 60-second duplicate window and documented it in the API contract. I kept the public ticket number generated on the backend from the database ID so the frontend cannot choose it. I will run the server tests and TypeScript build locally before opening the Feature 14 pull request.
+
 ## Reflection
 
 AI was useful for explaining unfamiliar concepts and organizing my work. However, I still need to understand the code, test every feature, read reviewer comments, and make the final implementation decisions myself.

--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -103,8 +103,9 @@ Success response `201`:
 Possible errors:
 
 - `400` for missing or invalid fields.
+- `400` when the selected requester, category, or related system is inactive.
 - `404` when the requester, category, or related system does not exist.
-- `409` when a duplicate ticket submission is detected.
+- `409` when the same requester submits the same category, related system, summary, description, and priority within 60 seconds.
 - `500` for an unexpected server error with a safe message.
 
 ## 4. My Tickets API

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -24,7 +24,7 @@ For each Lab 2 feature:
 | #11 | `feature/11-lab2-contract` | [PR #19](https://github.com/Thanwarat1303/toktickit/pull/19) | mxckiexz | Approved and merged |
 | #12 | `feature/12-data-seed` | [PR #20](https://github.com/Thanwarat1303/toktickit/pull/20) | mxckiexz | Approved and merged |
 | #13 | `feature/13-requester-selection` | To be added | mxckiexz | Implementation complete; awaiting PR |
-| #14 | `feature/14-create-ticket-api` | To be added | To be added | Not started |
+| #14 | `feature/14-create-ticket-api` | To be added | mxckiexz | Implementation complete; awaiting PR |
 | #15 | `feature/15-create-ticket-ui` | To be added | To be added | Not started |
 | #16 | `feature/16-my-tickets` | To be added | To be added | Not started |
 | #17 | `feature/17-ticket-detail-attachments` | To be added | To be added | Not started |

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -23,7 +23,7 @@ For each Lab 2 feature:
 | --- | --- | --- | --- | --- |
 | #11 | `feature/11-lab2-contract` | [PR #19](https://github.com/Thanwarat1303/toktickit/pull/19) | mxckiexz | Approved and merged |
 | #12 | `feature/12-data-seed` | [PR #20](https://github.com/Thanwarat1303/toktickit/pull/20) | mxckiexz | Approved and merged |
-| #13 | `feature/13-requester-selection` | To be added | mxckiexz | Implementation complete; awaiting PR |
+| #13 | `feature/13-requester-selection` | [PR #21](https://github.com/Thanwarat1303/toktickit/pull/21) | mxckiexz | Approved and merged |
 | #14 | `feature/14-create-ticket-api` | To be added | mxckiexz | Implementation complete; awaiting PR |
 | #15 | `feature/15-create-ticket-ui` | To be added | To be added | Not started |
 | #16 | `feature/16-my-tickets` | To be added | To be added | Not started |

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -14,11 +14,11 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 
 | Test ID | Type | Requirement / AC | What It Tests | Expected Result | Planned Test File | Status |
 | --- | --- | --- | --- | --- | --- | --- |
-| UNIT-01 | Unit | AC-02 | Ticket number generator | Generates a unique valid ticket number | `server/tests/lab-02/ticket-number.test.ts` | Planned |
+| UNIT-01 | Unit | AC-02 | Ticket number generator | Formats a database ID as the required ticket number | `server/tests/lab-02/ticket-number.test.ts` | Passed |
 | API-01 | API | AC-01 | Active requester list | Returns active requesters only | `server/tests/lab-02/requesters.api.test.ts` | Passed |
-| API-02 | API | AC-02 | Valid ticket creation | Creates a ticket with generated number and `New` status | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
-| API-03 | API | AC-03 | Required-field validation | Rejects missing or invalid ticket fields with `400` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
-| API-04 | API | AC-04 | Active reference validation | Rejects inactive or missing requester, category, and related system | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-02 | API | AC-02 | Valid ticket creation | Creates a ticket with generated number and `New` status | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
+| API-03 | API | AC-03, BR-07 | Required-field validation and duplicate prevention | Rejects invalid ticket data with `400` and matching rapid resubmission with `409` | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
+| API-04 | API | AC-04 | Active reference validation | Rejects inactive references with `400` and missing references with `404` | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
 | API-05 | API | AC-05 | My Tickets query behaviour | Returns requester-owned tickets with search, filters, sorting, and pagination | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-06 | API | AC-06 | Ticket ownership | Rejects another requester trying to read ticket detail | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-07 | API | AC-07 | Attachment upload | Accepts allowed files within size and active-count limits | `server/tests/lab-02/attachments.api.test.ts` | Planned |
@@ -105,6 +105,13 @@ Issue #13 verification results:
 - Backend and frontend TypeScript production builds passed.
 - API-01 verifies that only active requesters are returned in ID order.
 - UI-01 verifies loading, selection, persistence, changing requester, and API failure states.
+
+Issue #14 verification results:
+
+- UNIT-01 verifies the backend ticket-number format.
+- API-02 verifies that a valid request creates a ticket with a backend-generated number and `New` status.
+- API-03 verifies required values, invalid priority, and duplicate submission protection.
+- API-04 verifies missing and inactive requester, category, and related-system handling.
 
 Final submission evidence must show that all required tests pass and that no required test is skipped, disabled, or commented out.
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -18,6 +18,7 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 | API-01 | API | AC-01 | Active requester list | Returns active requesters only | `server/tests/lab-02/requesters.api.test.ts` | Passed |
 | API-02 | API | AC-02 | Valid ticket creation | Creates a ticket with generated number and `New` status | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
 | API-03 | API | AC-03, BR-07 | Required-field validation and duplicate prevention | Rejects invalid ticket data with `400` and matching rapid resubmission with `409` | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
+| API-03B | API Boundary | AC-03, BR-04 | Summary and description length limits | Accepts 100-character summaries and 2,000-character descriptions; rejects 101-character summaries and 2,001-character descriptions with `400` | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
 | API-04 | API | AC-04 | Active reference validation | Rejects inactive references with `400` and missing references with `404` | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
 | API-05 | API | AC-05 | My Tickets query behaviour | Returns requester-owned tickets with search, filters, sorting, and pagination | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-06 | API | AC-06 | Ticket ownership | Rejects another requester trying to read ticket detail | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
@@ -39,7 +40,7 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 | --- | --- | --- |
 | AC-01 — Development Requester Selection | DB-01, API-01, UI-01 | Seed-data test, API result, and requester selector screenshot |
 | AC-02 — Create Valid Ticket | UNIT-01, API-02, E2E-01 | Passing test output and created ticket screenshot |
-| AC-03 — Ticket Validation | API-03, UI-02 | Passing tests and validation-message screenshot |
+| AC-03 — Ticket Validation | API-03, API-03B, UI-02 | Passing tests and validation-message screenshot |
 | AC-04 — Active Reference Validation | DB-01, API-04 | Seed-data test and passing API test output |
 | AC-05 — Requester-Owned Ticket List | API-05, UI-03, E2E-01 | My Tickets screenshot with search, filters, sorting, and pagination |
 | AC-06 — Ownership Protection | API-06, E2E-01 | Passing API test and cross-requester access evidence |
@@ -111,6 +112,7 @@ Issue #14 verification results:
 - UNIT-01 verifies the backend ticket-number format.
 - API-02 verifies that a valid request creates a ticket with a backend-generated number and `New` status.
 - API-03 verifies required values, invalid priority, and duplicate submission protection.
+- API-03B verifies the exact and over-limit boundaries for summary (100/101 characters) and description (2,000/2,001 characters).
 - API-04 verifies missing and inactive requester, category, and related-system handling.
 
 Final submission evidence must show that all required tests pass and that no required test is skipped, disabled, or commented out.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,9 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
+import { Priority } from "@prisma/client";
+import { randomUUID } from "node:crypto";
 import { getPrisma } from "./prisma.js";
+import { generateTicketNumber } from "./ticket-number.js";
 
 export const app = express();
 
@@ -65,6 +68,162 @@ app.get("/api/requesters", async (_req: Request, res: Response) => {
     res.status(500).json({
       message: "Unable to load development requesters",
     });
+  }
+});
+
+// Lab 2, Issue 14 - Create Ticket API
+// The selected development requester is passed in X-Requester-Id. In Lab 3
+// this temporary header will be replaced by the authenticated user identity.
+const priorityValues: Record<string, Priority> = {
+  Low: Priority.LOW,
+  Medium: Priority.MEDIUM,
+  High: Priority.HIGH,
+};
+
+const duplicateWindowMs = 60_000;
+
+function positiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function createTicketResponse(ticket: {
+  id: number;
+  ticketNumber: string;
+  currentStatus: string;
+  requesterId: number;
+  categoryId: number;
+  relatedSystemId: number;
+  summary: string;
+  description: string;
+  priority: Priority;
+  createdAt: Date;
+}) {
+  return {
+    id: ticket.id,
+    ticketNumber: ticket.ticketNumber,
+    status: ticket.currentStatus,
+    requesterId: ticket.requesterId,
+    categoryId: ticket.categoryId,
+    relatedSystemId: ticket.relatedSystemId,
+    summary: ticket.summary,
+    description: ticket.description,
+    priority: ticket.priority[0] + ticket.priority.slice(1).toLowerCase(),
+    createdAt: ticket.createdAt,
+  };
+}
+
+app.post("/api/tickets", async (req: Request, res: Response) => {
+  const requesterId = Number(req.header("X-Requester-Id"));
+  const body = req.body ?? {};
+  const { categoryId, relatedSystemId, summary, description, priority } = body;
+
+  if (!positiveInteger(requesterId)) {
+    return res.status(400).json({ message: "A valid X-Requester-Id is required" });
+  }
+
+  if (!positiveInteger(categoryId)) {
+    return res.status(400).json({ message: "A valid categoryId is required" });
+  }
+
+  if (!positiveInteger(relatedSystemId)) {
+    return res.status(400).json({ message: "A valid relatedSystemId is required" });
+  }
+
+  if (typeof summary !== "string" || summary.trim().length === 0) {
+    return res.status(400).json({ message: "Summary is required" });
+  }
+
+  const trimmedSummary = summary.trim();
+  if (trimmedSummary.length > 100) {
+    return res.status(400).json({ message: "Summary must not exceed 100 characters" });
+  }
+
+  if (typeof description !== "string" || description.trim().length === 0) {
+    return res.status(400).json({ message: "Description is required" });
+  }
+
+  const trimmedDescription = description.trim();
+  if (trimmedDescription.length > 2000) {
+    return res.status(400).json({ message: "Description must not exceed 2000 characters" });
+  }
+
+  if (typeof priority !== "string" || !(priority in priorityValues)) {
+    return res.status(400).json({ message: "Priority must be Low, Medium, or High" });
+  }
+
+  try {
+    const prisma = getPrisma();
+    const requestedPriority = priorityValues[priority];
+
+    const result = await prisma.$transaction(async (tx) => {
+      const [requester, category, relatedSystem] = await Promise.all([
+        tx.requester.findUnique({ where: { id: requesterId } }),
+        tx.category.findUnique({ where: { id: categoryId } }),
+        tx.relatedSystem.findUnique({ where: { id: relatedSystemId } }),
+      ]);
+
+      if (!requester || !category || !relatedSystem) {
+        return { kind: "missing-reference" as const };
+      }
+
+      if (!requester.isActive || !category.isActive || !relatedSystem.isActive) {
+        return { kind: "inactive-reference" as const };
+      }
+
+      const recentDuplicate = await tx.ticket.findFirst({
+        where: {
+          requesterId,
+          categoryId,
+          relatedSystemId,
+          summary: trimmedSummary,
+          description: trimmedDescription,
+          priority: requestedPriority,
+          createdAt: { gte: new Date(Date.now() - duplicateWindowMs) },
+        },
+      });
+
+      if (recentDuplicate) {
+        return { kind: "duplicate" as const };
+      }
+
+      // A random placeholder satisfies the database's required unique column.
+      // The stable public ticket number is based on the generated database ID.
+      const insertedTicket = await tx.ticket.create({
+        data: {
+          ticketNumber: `PENDING-${randomUUID()}`,
+          requesterId,
+          categoryId,
+          relatedSystemId,
+          summary: trimmedSummary,
+          description: trimmedDescription,
+          priority: requestedPriority,
+          currentStatus: "New",
+        },
+      });
+
+      const ticket = await tx.ticket.update({
+        where: { id: insertedTicket.id },
+        data: { ticketNumber: generateTicketNumber(insertedTicket.id) },
+      });
+
+      return { kind: "created" as const, ticket };
+    });
+
+    if (result.kind === "missing-reference") {
+      return res.status(404).json({ message: "Requester, category, or related system was not found" });
+    }
+
+    if (result.kind === "inactive-reference") {
+      return res.status(400).json({ message: "Requester, category, and related system must be active" });
+    }
+
+    if (result.kind === "duplicate") {
+      return res.status(409).json({ message: "A matching ticket was submitted recently" });
+    }
+
+    return res.status(201).json(createTicketResponse(result.ticket));
+  } catch {
+    return res.status(500).json({ message: "Unable to create the ticket" });
   }
 });
 

--- a/server/src/ticket-number.ts
+++ b/server/src/ticket-number.ts
@@ -1,0 +1,7 @@
+/**
+ * Converts the database-generated Ticket ID into the public ticket number.
+ * The backend owns this identifier; the frontend never sends or chooses it.
+ */
+export function generateTicketNumber(ticketId: number): string {
+  return `TK-${String(ticketId).padStart(6, "0")}`;
+}

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+
+const prisma = getPrisma();
+const marker = `Feature 14 automated test ${Date.now()}`;
+
+let activeRequesterId: number;
+let inactiveRequesterId: number;
+let activeCategoryId: number;
+let inactiveCategoryId: number;
+let activeRelatedSystemId: number;
+let inactiveRelatedSystemId: number;
+
+function validTicketBody(overrides: Record<string, unknown> = {}) {
+  return {
+    categoryId: activeCategoryId,
+    relatedSystemId: activeRelatedSystemId,
+    summary: `${marker} - Wi-Fi connection issue`,
+    description: "The test device cannot connect to the campus Wi-Fi network.",
+    priority: "Medium",
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  const [activeRequester, inactiveRequester, activeCategory, inactiveCategory, activeSystem, inactiveSystem] =
+    await Promise.all([
+      prisma.requester.findFirstOrThrow({ where: { isActive: true }, orderBy: { id: "asc" } }),
+      prisma.requester.findFirstOrThrow({ where: { isActive: false }, orderBy: { id: "asc" } }),
+      prisma.category.findFirstOrThrow({ where: { isActive: true }, orderBy: { id: "asc" } }),
+      prisma.category.findFirstOrThrow({ where: { isActive: false }, orderBy: { id: "asc" } }),
+      prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true }, orderBy: { id: "asc" } }),
+      prisma.relatedSystem.findFirstOrThrow({ where: { isActive: false }, orderBy: { id: "asc" } }),
+    ]);
+
+  activeRequesterId = activeRequester.id;
+  inactiveRequesterId = inactiveRequester.id;
+  activeCategoryId = activeCategory.id;
+  inactiveCategoryId = inactiveCategory.id;
+  activeRelatedSystemId = activeSystem.id;
+  inactiveRelatedSystemId = inactiveSystem.id;
+});
+
+afterAll(async () => {
+  await prisma.ticket.deleteMany({
+    where: {
+      summary: {
+        startsWith: marker,
+      },
+    },
+  });
+  await prisma.$disconnect();
+});
+
+describe("POST /api/tickets", () => {
+  it("creates a valid ticket with a backend-generated number and New status", async () => {
+    const response = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(validTicketBody({
+        summary: `  ${marker} - trim this summary  `,
+        description: "  The saved description is trimmed by the API.  ",
+      }));
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      ticketNumber: expect.stringMatching(/^TK-\d{6}$/),
+      status: "New",
+      requesterId: activeRequesterId,
+      categoryId: activeCategoryId,
+      relatedSystemId: activeRelatedSystemId,
+      summary: `${marker} - trim this summary`,
+      description: "The saved description is trimmed by the API.",
+      priority: "Medium",
+    });
+  });
+
+  it("rejects missing and invalid ticket fields", async () => {
+    const response = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(validTicketBody({ summary: "   " }));
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toMatch(/summary is required/i);
+  });
+
+  it("rejects an invalid priority and an invalid requester header", async () => {
+    const invalidPriority = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(validTicketBody({ priority: "Urgent" }));
+
+    const invalidRequester = await request(app)
+      .post("/api/tickets")
+      .send(validTicketBody());
+
+    expect(invalidPriority.status).toBe(400);
+    expect(invalidPriority.body.message).toMatch(/priority/i);
+    expect(invalidRequester.status).toBe(400);
+    expect(invalidRequester.body.message).toMatch(/requester/i);
+  });
+
+  it("rejects missing reference data with a safe not-found response", async () => {
+    const response = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(validTicketBody({ categoryId: 999999 }));
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toMatch(/not found/i);
+  });
+
+  it("rejects inactive requester, category, and related-system references", async () => {
+    const inactiveRequester = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(inactiveRequesterId))
+      .send(validTicketBody({ summary: `${marker} - inactive requester` }));
+
+    const inactiveCategory = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(validTicketBody({
+        categoryId: inactiveCategoryId,
+        summary: `${marker} - inactive category`,
+      }));
+
+    const inactiveSystem = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(validTicketBody({
+        relatedSystemId: inactiveRelatedSystemId,
+        summary: `${marker} - inactive system`,
+      }));
+
+    expect(inactiveRequester.status).toBe(400);
+    expect(inactiveCategory.status).toBe(400);
+    expect(inactiveSystem.status).toBe(400);
+  });
+
+  it("prevents a duplicate ticket from the same requester within the duplicate window", async () => {
+    const body = validTicketBody({ summary: `${marker} - duplicate submission` });
+
+    const firstResponse = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(body);
+
+    const duplicateResponse = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(body);
+
+    expect(firstResponse.status).toBe(201);
+    expect(duplicateResponse.status).toBe(409);
+    expect(duplicateResponse.body.message).toMatch(/submitted recently/i);
+  });
+});

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -87,6 +87,43 @@ describe("POST /api/tickets", () => {
     expect(response.body.message).toMatch(/summary is required/i);
   });
 
+  it("accepts a summary with exactly 100 characters and rejects one with 101 characters", async () => {
+    const summaryAtLimit = `${marker}${"s".repeat(100 - marker.length)}`;
+    const summaryOverLimit = `${marker}${"s".repeat(101 - marker.length)}`;
+
+    const acceptedResponse = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(validTicketBody({ summary: summaryAtLimit }));
+
+    const rejectedResponse = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(validTicketBody({ summary: summaryOverLimit }));
+
+    expect(acceptedResponse.status).toBe(201);
+    expect(acceptedResponse.body.summary).toHaveLength(100);
+    expect(rejectedResponse.status).toBe(400);
+    expect(rejectedResponse.body.message).toMatch(/summary must not exceed 100 characters/i);
+  });
+
+  it("accepts a description with exactly 2000 characters and rejects one with 2001 characters", async () => {
+    const acceptedResponse = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(validTicketBody({ description: "d".repeat(2000) }));
+
+    const rejectedResponse = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", String(activeRequesterId))
+      .send(validTicketBody({ description: "d".repeat(2001) }));
+
+    expect(acceptedResponse.status).toBe(201);
+    expect(acceptedResponse.body.description).toHaveLength(2000);
+    expect(rejectedResponse.status).toBe(400);
+    expect(rejectedResponse.body.message).toMatch(/description must not exceed 2000 characters/i);
+  });
+
   it("rejects an invalid priority and an invalid requester header", async () => {
     const invalidPriority = await request(app)
       .post("/api/tickets")

--- a/server/tests/lab-02/ticket-number.test.ts
+++ b/server/tests/lab-02/ticket-number.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { generateTicketNumber } from "../../src/ticket-number.js";
+
+describe("generateTicketNumber", () => {
+  it("formats database IDs as six-digit TokTickIT ticket numbers", () => {
+    expect(generateTicketNumber(1)).toBe("TK-000001");
+    expect(generateTicketNumber(42)).toBe("TK-000042");
+    expect(generateTicketNumber(123456)).toBe("TK-123456");
+  });
+});


### PR DESCRIPTION
## Summary

- Added `POST /api/tickets`.
- The API reads the selected requester from `X-Requester-Id`.
- Added validation for required fields, field lengths, and priority.
- Added checks for missing and inactive requester, category, and related system data.
- The backend generates a unique ticket number and sets the initial status to `New`.
- Added duplicate submission protection for matching requests within 60 seconds.
- Updated the API contract, test plan, reviewer record, and AI-use record.

## Testing

- `npm test` — 6 test files and 16 tests passed.
- `npm run build` — passed.

## Scope

This PR implements the backend Create Ticket API only. The Create Ticket form, My Tickets, ticket detail, and attachments are handled in later features.