### PR TITLE
feat: add ticket detail and attachment handling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import {
 import RequesterSelector from "./RequesterSelector.js";
 import CreateTicketForm from "./CreateTicketForm.js";
 import MyTickets from "./MyTickets.js";
+import TicketDetail from "./TicketDetail.js";
 
 type UiState = "idle" | "loading" | "success" | "error";
 const REQUESTER_STORAGE_KEY = "toktickit.developmentRequester";
@@ -33,6 +34,7 @@ export default function App() {
     loadSavedRequester
   );
   const [view, setView] = useState<"create" | "tickets">("create");
+  const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
 
   function handleRequesterSelect(selectedRequester: Requester) {
     localStorage.setItem(
@@ -47,6 +49,7 @@ export default function App() {
     localStorage.removeItem(REQUESTER_STORAGE_KEY);
     setRequester(null);
     setView("create");
+    setSelectedTicketId(null);
   }
 
   async function handleCheck() {
@@ -120,10 +123,20 @@ export default function App() {
               </button>
             </section>
             <nav className="app-nav" aria-label="Ticket views">
-              <button className={view === "create" ? "app-nav__tab active" : "app-nav__tab"} onClick={() => setView("create")}>New Ticket</button>
+              <button className={view === "create" ? "app-nav__tab active" : "app-nav__tab"} onClick={() => { setView("create"); setSelectedTicketId(null); }}>New Ticket</button>
               <button className={view === "tickets" ? "app-nav__tab active" : "app-nav__tab"} onClick={() => setView("tickets")}>My Tickets</button>
             </nav>
-            {view === "create" ? <CreateTicketForm requester={requester} /> : <MyTickets requester={requester} />}
+            {view === "create" ? (
+              <CreateTicketForm requester={requester} />
+            ) : selectedTicketId ? (
+              <TicketDetail
+                requester={requester}
+                ticketId={selectedTicketId}
+                onBack={() => setSelectedTicketId(null)}
+              />
+            ) : (
+              <MyTickets requester={requester} onOpenTicket={setSelectedTicketId} />
+            )}
           </>
         )}
 

--- a/client/src/MyTickets.tsx
+++ b/client/src/MyTickets.tsx
@@ -14,9 +14,10 @@ type SortValue = "createdAt-desc" | "createdAt-asc" | "summary-asc" | "summary-d
 
 interface MyTicketsProps {
   requester: Requester;
+  onOpenTicket: (ticketId: number) => void;
 }
 
-export default function MyTickets({ requester }: MyTicketsProps) {
+export default function MyTickets({ requester, onOpenTicket }: MyTicketsProps) {
   const [search, setSearch] = useState("");
   const [categoryId, setCategoryId] = useState("");
   const [relatedSystemId, setRelatedSystemId] = useState("");
@@ -151,7 +152,15 @@ export default function MyTickets({ requester }: MyTicketsProps) {
               <thead><tr><th>Ticket</th><th>Summary</th><th>Category</th><th>System</th><th>Priority</th><th>Status</th><th>Created</th></tr></thead>
               <tbody>{data.items.map((ticket) => (
                 <tr key={ticket.id}>
-                  <td><code>{ticket.ticketNumber}</code></td><td>{ticket.summary}</td><td>{ticket.category.name}</td><td>{ticket.relatedSystem.name}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="ticket-link"
+                      onClick={() => onOpenTicket(ticket.id)}
+                    >
+                      {ticket.ticketNumber}
+                    </button>
+                  </td><td>{ticket.summary}</td><td>{ticket.category.name}</td><td>{ticket.relatedSystem.name}</td>
                   <td><span className={`priority-badge priority-badge--${ticket.priority.toLowerCase()}`}>{ticket.priority}</span></td>
                   <td><span className="status-badge">{ticket.status}</span></td><td>{new Date(ticket.createdAt).toLocaleString()}</td>
                 </tr>

--- a/client/src/TicketDetail.tsx
+++ b/client/src/TicketDetail.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from "react";
+import {
+  ApiRequestError,
+  attachmentDownloadUrl,
+  getTicketAttachments,
+  getTicketDetail,
+  removeAttachment,
+  type AttachmentSummary,
+  type Requester,
+  type TicketDetail as TicketDetailData,
+} from "./api.js";
+
+interface TicketDetailProps {
+  requester: Requester;
+  ticketId: number;
+  onBack: () => void;
+}
+
+function formatBytes(sizeBytes: number) {
+  if (sizeBytes < 1024) return `${sizeBytes} B`;
+  if (sizeBytes < 1024 * 1024) return `${(sizeBytes / 1024).toFixed(1)} KB`;
+  return `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function TicketDetail({ requester, ticketId, onBack }: TicketDetailProps) {
+  const [ticket, setTicket] = useState<TicketDetailData | null>(null);
+  const [attachments, setAttachments] = useState<AttachmentSummary[]>([]);
+  const [loadingTicket, setLoadingTicket] = useState(true);
+  const [loadingAttachments, setLoadingAttachments] = useState(true);
+  const [ticketError, setTicketError] = useState("");
+  const [attachmentError, setAttachmentError] = useState("");
+  const [removingId, setRemovingId] = useState<number | null>(null);
+
+  async function loadAttachments() {
+    setLoadingAttachments(true);
+    setAttachmentError("");
+
+    try {
+      const loadedAttachments = await getTicketAttachments(ticketId, requester.id);
+      setAttachments(loadedAttachments);
+    } catch (caught) {
+      setAttachmentError(
+        caught instanceof ApiRequestError
+          ? caught.message
+          : "Unable to load ticket attachments."
+      );
+    } finally {
+      setLoadingAttachments(false);
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setLoadingTicket(true);
+    setTicketError("");
+
+    getTicketDetail(ticketId, requester.id)
+      .then((loadedTicket) => {
+        if (!cancelled) setTicket(loadedTicket);
+      })
+      .catch((caught) => {
+        if (!cancelled) {
+          setTicket(null);
+          setTicketError(
+            caught instanceof ApiRequestError
+              ? caught.message
+              : "Unable to load ticket details."
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingTicket(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ticketId, requester.id]);
+
+  useEffect(() => {
+    void loadAttachments();
+  }, [ticketId, requester.id]);
+
+  async function handleRemoveAttachment(attachment: AttachmentSummary) {
+    const reason = window.prompt(
+      `Why do you want to remove "${attachment.originalFilename}"?`
+    );
+
+    if (!reason?.trim()) return;
+
+    setRemovingId(attachment.id);
+    setAttachmentError("");
+
+    try {
+      const removedAttachment = await removeAttachment(
+        attachment.id,
+        requester.id,
+        reason
+      );
+
+      setAttachments((currentAttachments) =>
+        currentAttachments.map((current) =>
+          current.id === removedAttachment.id ? removedAttachment : current
+        )
+      );
+    } catch (caught) {
+      setAttachmentError(
+        caught instanceof ApiRequestError
+          ? caught.message
+          : "Unable to remove the attachment."
+      );
+    } finally {
+      setRemovingId(null);
+    }
+  }
+
+  return (
+    <section className="ticket-detail-card" aria-labelledby="ticket-detail-heading">
+      <button type="button" className="btn btn-outline-zen mb-4" onClick={onBack}>
+        ← Back to My Tickets
+      </button>
+
+      {loadingTicket && <div className="state-panel">Loading ticket details…</div>}
+
+      {!loadingTicket && ticketError && (
+        <div role="alert" className="state-panel state-panel--error">
+          {ticketError}
+        </div>
+      )}
+
+      {!loadingTicket && ticket && (
+        <>
+          <div className="ticket-detail-card__header">
+            <div>
+              <p className="eyebrow mb-1">Ticket detail</p>
+              <h2 id="ticket-detail-heading" className="h3 mb-2">
+                {ticket.ticketNumber}
+              </h2>
+              <p className="text-secondary mb-0">{ticket.summary}</p>
+            </div>
+            <span className="status-badge">{ticket.status}</span>
+          </div>
+
+          <dl className="ticket-detail-grid">
+            <div><dt>Requester</dt><dd>{ticket.requester.name}</dd></div>
+            <div><dt>Category</dt><dd>{ticket.category.name}</dd></div>
+            <div><dt>Related system</dt><dd>{ticket.relatedSystem.name}</dd></div>
+            <div><dt>Priority</dt><dd><span className={`priority-badge priority-badge--${ticket.priority.toLowerCase()}`}>{ticket.priority}</span></dd></div>
+            <div><dt>Created</dt><dd>{new Date(ticket.createdAt).toLocaleString()}</dd></div>
+            <div><dt>Last updated</dt><dd>{new Date(ticket.updatedAt).toLocaleString()}</dd></div>
+          </dl>
+
+          <div className="ticket-description">
+            <h3 className="h5">Description</h3>
+            <p className="mb-0">{ticket.description}</p>
+          </div>
+        </>
+      )}
+
+      <section className="attachments-panel mt-4" aria-labelledby="attachments-heading">
+        <div className="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-3">
+          <div>
+            <p className="eyebrow mb-1">Supporting files</p>
+            <h3 id="attachments-heading" className="h5 mb-0">Attachments</h3>
+          </div>
+          <button
+            type="button"
+            className="btn btn-outline-zen"
+            onClick={() => void loadAttachments()}
+            disabled={loadingAttachments}
+          >
+            {loadingAttachments ? "Refreshing..." : "Refresh"}
+          </button>
+        </div>
+
+        {loadingAttachments && <div className="state-panel">Loading attachments…</div>}
+
+        {!loadingAttachments && attachmentError && (
+          <div role="alert" className="state-panel state-panel--error">
+            {attachmentError}
+          </div>
+        )}
+
+        {!loadingAttachments && !attachmentError && attachments.length === 0 && (
+          <div className="empty-state">
+            <h4 className="h6">No attachments yet</h4>
+            <p className="mb-0">Uploaded files for this ticket will appear here.</p>
+          </div>
+        )}
+
+        {!loadingAttachments && !attachmentError && attachments.length > 0 && (
+          <ul className="attachment-list">
+            {attachments.map((attachment) => {
+              const isRemoved = Boolean(attachment.removedAt);
+
+              return (
+                <li
+                  key={attachment.id}
+                  className={isRemoved ? "attachment-item attachment-item--removed" : "attachment-item"}
+                >
+                  <div>
+                    <strong>{attachment.originalFilename}</strong>
+                    <p className="mb-0 text-secondary">
+                      {attachment.mimeType} · {formatBytes(attachment.sizeBytes)} · Uploaded {new Date(attachment.createdAt).toLocaleString()}
+                    </p>
+                    {isRemoved && (
+                      <p className="mb-0 text-secondary">
+                        Removed {new Date(attachment.removedAt as string).toLocaleString()}
+                        {attachment.removalReason ? ` — ${attachment.removalReason}` : ""}
+                      </p>
+                    )}
+                  </div>
+
+                  {isRemoved ? (
+                    <span className="status-badge">Removed</span>
+                  ) : (
+                    <div className="attachment-actions">
+                      <a
+                        className="btn btn-outline-zen"
+                        href={attachmentDownloadUrl(attachment.id, requester.id)}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Download
+                      </a>
+                      <button
+                        type="button"
+                        className="btn btn-outline-danger"
+                        onClick={() => void handleRemoveAttachment(attachment)}
+                        disabled={removingId === attachment.id}
+                      >
+                        {removingId === attachment.id ? "Removing..." : "Remove"}
+                      </button>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/client/src/TicketDetail.tsx
+++ b/client/src/TicketDetail.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { type FormEvent, useEffect, useState } from "react";
 import {
   ApiRequestError,
   attachmentDownloadUrl,
   getTicketAttachments,
   getTicketDetail,
   removeAttachment,
+  uploadTicketAttachment,
   type AttachmentSummary,
   type Requester,
   type TicketDetail as TicketDetailData,
@@ -22,6 +23,15 @@ function formatBytes(sizeBytes: number) {
   return `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+const allowedAttachmentTypes = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+]);
+const maxAttachmentBytes = 5 * 1024 * 1024;
+const maxActiveAttachments = 5;
+
 export default function TicketDetail({ requester, ticketId, onBack }: TicketDetailProps) {
   const [ticket, setTicket] = useState<TicketDetailData | null>(null);
   const [attachments, setAttachments] = useState<AttachmentSummary[]>([]);
@@ -30,6 +40,14 @@ export default function TicketDetail({ requester, ticketId, onBack }: TicketDeta
   const [ticketError, setTicketError] = useState("");
   const [attachmentError, setAttachmentError] = useState("");
   const [removingId, setRemovingId] = useState<number | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [uploadError, setUploadError] = useState("");
+  const [uploadSuccess, setUploadSuccess] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [fileInputKey, setFileInputKey] = useState(0);
+
+  const activeAttachmentCount = attachments.filter((attachment) => !attachment.removedAt).length;
+  const attachmentLimitReached = activeAttachmentCount >= maxActiveAttachments;
 
   async function loadAttachments() {
     setLoadingAttachments(true);
@@ -115,6 +133,50 @@ export default function TicketDetail({ requester, ticketId, onBack }: TicketDeta
     }
   }
 
+  async function handleUploadAttachment(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setUploadError("");
+    setUploadSuccess("");
+
+    if (attachmentLimitReached) {
+      setUploadError("This ticket already has five active attachments.");
+      return;
+    }
+
+    if (!selectedFile) {
+      setUploadError("Choose a file before uploading.");
+      return;
+    }
+
+    if (!allowedAttachmentTypes.has(selectedFile.type)) {
+      setUploadError("Unsupported file type. Use JPG, PNG, WEBP, or PDF.");
+      return;
+    }
+
+    if (selectedFile.size > maxAttachmentBytes) {
+      setUploadError("Attachment must not exceed 5 MB.");
+      return;
+    }
+
+    setUploading(true);
+
+    try {
+      await uploadTicketAttachment(ticketId, requester.id, selectedFile);
+      setSelectedFile(null);
+      setFileInputKey((currentKey) => currentKey + 1);
+      setUploadSuccess("Attachment uploaded successfully.");
+      await loadAttachments();
+    } catch (caught) {
+      setUploadError(
+        caught instanceof ApiRequestError
+          ? caught.message
+          : "Unable to upload the attachment."
+      );
+    } finally {
+      setUploading(false);
+    }
+  }
+
   return (
     <section className="ticket-detail-card" aria-labelledby="ticket-detail-heading">
       <button type="button" className="btn btn-outline-zen mb-4" onClick={onBack}>
@@ -180,6 +242,54 @@ export default function TicketDetail({ requester, ticketId, onBack }: TicketDeta
           <div role="alert" className="state-panel state-panel--error">
             {attachmentError}
           </div>
+        )}
+
+        {!loadingAttachments && !attachmentError && (
+          <form className="attachment-upload-form" onSubmit={(event) => void handleUploadAttachment(event)}>
+            <div>
+              <label htmlFor="ticket-attachment" className="form-label">
+                Add an attachment ({activeAttachmentCount}/5)
+              </label>
+              <input
+                key={fileInputKey}
+                id="ticket-attachment"
+                className="form-control"
+                type="file"
+                accept=".jpg,.jpeg,.png,.webp,.pdf,image/jpeg,image/png,image/webp,application/pdf"
+                disabled={uploading || attachmentLimitReached}
+                onChange={(event) => {
+                  setUploadError("");
+                  setUploadSuccess("");
+                  setSelectedFile(event.target.files?.[0] ?? null);
+                }}
+              />
+              <p className="form-help mb-0">
+                JPG, PNG, WEBP, or PDF only. Maximum 5 MB. Maximum five active attachments per ticket.
+              </p>
+            </div>
+            <button
+              type="submit"
+              className="btn btn-zen"
+              disabled={uploading || attachmentLimitReached}
+            >
+              {uploading ? "Uploading..." : "Upload attachment"}
+            </button>
+            {attachmentLimitReached && (
+              <p className="form-help attachment-upload-form__message mb-0">
+                Attachment limit reached. Remove an active attachment before adding another.
+              </p>
+            )}
+            {uploadError && (
+              <p role="alert" className="field-error attachment-upload-form__message mb-0">
+                {uploadError}
+              </p>
+            )}
+            {uploadSuccess && (
+              <p className="success-message attachment-upload-form__message mb-0">
+                {uploadSuccess}
+              </p>
+            )}
+          </form>
         )}
 
         {!loadingAttachments && !attachmentError && attachments.length === 0 && (

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -237,6 +237,29 @@ export async function getTicketAttachments(
   return response.json();
 }
 
+export async function uploadTicketAttachment(
+  ticketId: number,
+  requesterId: number,
+  file: File
+): Promise<AttachmentSummary> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments`, {
+    method: "POST",
+    headers: {
+      "X-Requester-Id": String(requesterId),
+    },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new ApiRequestError(await getErrorMessage(response, "Unable to upload attachment"));
+  }
+
+  return response.json();
+}
+
 export function attachmentDownloadUrl(attachmentId: number, requesterId: number): string {
   return `${API_URL}/api/attachments/${attachmentId}/download?requesterId=${requesterId}`;
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -54,6 +54,31 @@ export interface TicketListItem {
   createdAt: string;
 }
 
+export interface TicketDetail {
+  id: number;
+  ticketNumber: string;
+  requester: Requester;
+  category: Category;
+  relatedSystem: RelatedSystem;
+  summary: string;
+  description: string;
+  priority: "Low" | "Medium" | "High";
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AttachmentSummary {
+  id: number;
+  ticketId: number;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+  removedAt: string | null;
+  removalReason: string | null;
+}
+
 export interface TicketListResponse {
   items: TicketListItem[];
   page: number;
@@ -173,6 +198,65 @@ export async function getTickets(query: TicketListQuery): Promise<TicketListResp
 
   if (!response.ok) {
     throw new ApiRequestError(await getErrorMessage(response, "Unable to load tickets"));
+  }
+
+  return response.json();
+}
+
+export async function getTicketDetail(
+  ticketId: number,
+  requesterId: number
+): Promise<TicketDetail> {
+  const response = await fetch(`${API_URL}/api/tickets/${ticketId}`, {
+    headers: {
+      "X-Requester-Id": String(requesterId),
+    },
+  });
+
+  if (!response.ok) {
+    throw new ApiRequestError(await getErrorMessage(response, "Unable to load ticket details"));
+  }
+
+  return response.json();
+}
+
+export async function getTicketAttachments(
+  ticketId: number,
+  requesterId: number
+): Promise<AttachmentSummary[]> {
+  const response = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments`, {
+    headers: {
+      "X-Requester-Id": String(requesterId),
+    },
+  });
+
+  if (!response.ok) {
+    throw new ApiRequestError(await getErrorMessage(response, "Unable to load attachments"));
+  }
+
+  return response.json();
+}
+
+export function attachmentDownloadUrl(attachmentId: number, requesterId: number): string {
+  return `${API_URL}/api/attachments/${attachmentId}/download?requesterId=${requesterId}`;
+}
+
+export async function removeAttachment(
+  attachmentId: number,
+  requesterId: number,
+  removalReason: string
+): Promise<AttachmentSummary> {
+  const response = await fetch(`${API_URL}/api/attachments/${attachmentId}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Requester-Id": String(requesterId),
+    },
+    body: JSON.stringify({ removalReason }),
+  });
+
+  if (!response.ok) {
+    throw new ApiRequestError(await getErrorMessage(response, "Unable to remove attachment"));
   }
 
   return response.json();

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -83,7 +83,8 @@ body {
 .selected-card,
 .system-card,
 .ticket-form-card,
-.ticket-success-card {
+.ticket-success-card,
+.ticket-detail-card {
   border: 1px solid var(--zen-border);
   border-radius: 1.35rem;
   background: rgba(255, 255, 255, 0.94);
@@ -265,8 +266,95 @@ body {
 .ticket-filters label { display: grid; gap: 0.35rem; font-size: 0.83rem; font-weight: 700; }
 .ticket-table th { color: var(--zen-muted); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; }
 .ticket-table code { color: var(--zen-primary); font-weight: 800; }
+.ticket-link {
+  padding: 0;
+  border: 0;
+  color: var(--zen-primary);
+  background: transparent;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 800;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+.ticket-link:hover,
+.ticket-link:focus-visible {
+  color: var(--zen-secondary);
+}
 .ticket-pagination { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
 .empty-state { padding: 2.2rem 1rem; border: 1px dashed var(--zen-border); border-radius: 1rem; color: var(--zen-muted); text-align: center; }
+
+.ticket-detail-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--zen-border);
+}
+
+.ticket-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.ticket-detail-grid div,
+.ticket-description,
+.attachments-panel {
+  padding: 1rem;
+  border: 1px solid var(--zen-border);
+  border-radius: 1rem;
+  background: #fff;
+}
+
+.ticket-detail-grid dt {
+  color: var(--zen-muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.ticket-detail-grid dd {
+  margin: 0.35rem 0 0;
+  font-weight: 700;
+}
+
+.attachment-list {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.attachment-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--zen-border);
+  border-radius: 0.9rem;
+  background: var(--zen-pale);
+}
+
+.attachment-item--removed {
+  opacity: 0.78;
+  background: #f5f7f6;
+}
+
+.attachment-item--removed strong {
+  text-decoration: line-through;
+}
+
+.attachment-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
 
 .requester-chip {
   display: flex;
@@ -323,7 +411,9 @@ body {
 
   .selected-card,
   .state-panel--error,
-  .ticket-form-card__heading {
+    .ticket-form-card__heading,
+    .ticket-detail-card__header,
+    .attachment-item {
     align-items: stretch;
     flex-direction: column;
   }
@@ -334,5 +424,8 @@ body {
   }
 
   .ticket-filters { grid-template-columns: 1fr; }
+  .ticket-detail-grid { grid-template-columns: 1fr; }
   .ticket-pagination { align-items: stretch; flex-direction: column; }
+  .attachment-actions { width: 100%; justify-content: stretch; }
+  .attachment-actions .btn { flex: 1; }
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -308,6 +308,22 @@ body {
   background: #fff;
 }
 
+.attachment-upload-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.85rem;
+  align-items: end;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--zen-border);
+  border-radius: 0.9rem;
+  background: #f5f7f6;
+}
+
+.attachment-upload-form__message {
+  grid-column: 1 / -1;
+}
+
 .ticket-detail-grid dt {
   color: var(--zen-muted);
   font-size: 0.76rem;
@@ -426,6 +442,7 @@ body {
   .ticket-filters { grid-template-columns: 1fr; }
   .ticket-detail-grid { grid-template-columns: 1fr; }
   .ticket-pagination { align-items: stretch; flex-direction: column; }
+  .attachment-upload-form { grid-template-columns: 1fr; }
   .attachment-actions { width: 100%; justify-content: stretch; }
   .attachment-actions .btn { flex: 1; }
 }

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -22,7 +22,7 @@ describe("My Tickets", () => {
 
   it("loads the active requester's ticket list", async () => {
     mockTickets();
-    render(<MyTickets requester={requester} />);
+    render(<MyTickets requester={requester} onOpenTicket={vi.fn()} />);
 
     expect(await screen.findByText("Wi-Fi is unavailable")).toBeInTheDocument();
     expect(api.getTickets).toHaveBeenCalledWith(expect.objectContaining({ requesterId: 1, page: 1 }));
@@ -30,7 +30,7 @@ describe("My Tickets", () => {
 
   it("resets to page one when a filter changes", async () => {
     mockTickets();
-    render(<MyTickets requester={requester} />);
+    render(<MyTickets requester={requester} onOpenTicket={vi.fn()} />);
 
     await screen.findByText("Wi-Fi is unavailable");
     fireEvent.change(screen.getByLabelText("Priority"), { target: { value: "High" } });
@@ -42,8 +42,18 @@ describe("My Tickets", () => {
     vi.spyOn(api, "getCategories").mockResolvedValue([]);
     vi.spyOn(api, "getRelatedSystems").mockResolvedValue([]);
     vi.spyOn(api, "getTickets").mockResolvedValue({ items: [], page: 1, pageSize: 10, totalItems: 0, totalPages: 1 });
-    render(<MyTickets requester={requester} />);
+    render(<MyTickets requester={requester} onOpenTicket={vi.fn()} />);
 
     expect(await screen.findByText("No tickets yet")).toBeInTheDocument();
+  });
+
+  it("opens the ticket detail view when the ticket number is clicked", async () => {
+    const onOpenTicket = vi.fn();
+    mockTickets();
+    render(<MyTickets requester={requester} onOpenTicket={onOpenTicket} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "TK-000001" }));
+
+    expect(onOpenTicket).toHaveBeenCalledWith(1);
   });
 });

--- a/client/tests/lab-02/TicketDetail.test.tsx
+++ b/client/tests/lab-02/TicketDetail.test.tsx
@@ -91,6 +91,99 @@ describe("Ticket Detail", () => {
     expect(screen.queryByRole("link", { name: /Download/i })).not.toBeInTheDocument();
   });
 
+  it("uploads a selected attachment and refreshes the attachment list", async () => {
+    const uploadFile = new File(["ticket evidence"], "ticket-evidence.pdf", {
+      type: "application/pdf",
+    });
+    vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket);
+    vi.spyOn(api, "getTicketAttachments")
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 6,
+          ticketId: 10,
+          originalFilename: "ticket-evidence.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: uploadFile.size,
+          createdAt: "2026-09-01T12:00:00.000Z",
+          removedAt: null,
+          removalReason: null,
+        },
+      ]);
+    vi.spyOn(api, "uploadTicketAttachment").mockResolvedValue({
+      id: 6,
+      ticketId: 10,
+      originalFilename: "ticket-evidence.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: uploadFile.size,
+      createdAt: "2026-09-01T12:00:00.000Z",
+      removedAt: null,
+      removalReason: null,
+    });
+
+    render(<TicketDetail requester={requester} ticketId={10} onBack={vi.fn()} />);
+
+    const fileInput = await screen.findByLabelText(/Add an attachment/i);
+    fireEvent.change(fileInput, { target: { files: [uploadFile] } });
+    fireEvent.click(screen.getByRole("button", { name: /Upload attachment/i }));
+
+    await waitFor(() => {
+      expect(api.uploadTicketAttachment).toHaveBeenCalledWith(10, 1, uploadFile);
+    });
+    expect(await screen.findByText("Attachment uploaded successfully.")).toBeInTheDocument();
+    expect(await screen.findByText("ticket-evidence.pdf")).toBeInTheDocument();
+  });
+
+  it("blocks unsupported files before calling the upload API", async () => {
+    const unsupportedFile = new File(["bad"], "malware.exe", {
+      type: "application/x-msdownload",
+    });
+    vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket);
+    vi.spyOn(api, "getTicketAttachments").mockResolvedValue([]);
+    const uploadSpy = vi.spyOn(api, "uploadTicketAttachment").mockResolvedValue({
+      id: 6,
+      ticketId: 10,
+      originalFilename: "malware.exe",
+      mimeType: "application/x-msdownload",
+      sizeBytes: unsupportedFile.size,
+      createdAt: "2026-09-01T12:00:00.000Z",
+      removedAt: null,
+      removalReason: null,
+    });
+
+    render(<TicketDetail requester={requester} ticketId={10} onBack={vi.fn()} />);
+
+    fireEvent.change(await screen.findByLabelText(/Add an attachment/i), {
+      target: { files: [unsupportedFile] },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Upload attachment/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/Unsupported file type/i);
+    expect(uploadSpy).not.toHaveBeenCalled();
+  });
+
+  it("disables attachment upload when the ticket already has five active attachments", async () => {
+    vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket);
+    vi.spyOn(api, "getTicketAttachments").mockResolvedValue(
+      Array.from({ length: 5 }, (_, index) => ({
+        id: index + 1,
+        ticketId: 10,
+        originalFilename: `evidence-${index + 1}.pdf`,
+        mimeType: "application/pdf",
+        sizeBytes: 1024,
+        createdAt: "2026-09-01T10:05:00.000Z",
+        removedAt: null,
+        removalReason: null,
+      }))
+    );
+
+    render(<TicketDetail requester={requester} ticketId={10} onBack={vi.fn()} />);
+
+    expect(await screen.findByLabelText(/Add an attachment \(5\/5\)/i)).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Upload attachment/i })).toBeDisabled();
+    expect(screen.getByText(/Attachment limit reached/i)).toBeInTheDocument();
+  });
+
   it("returns to My Tickets when Back is clicked", async () => {
     const onBack = vi.fn();
     vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket);

--- a/client/tests/lab-02/TicketDetail.test.tsx
+++ b/client/tests/lab-02/TicketDetail.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import TicketDetail from "../../src/TicketDetail.js";
+import * as api from "../../src/api.js";
+
+const requester: api.Requester = {
+  id: 1,
+  name: "Anan Student",
+  email: "anan.student@toktickit.local",
+};
+
+const ticket: api.TicketDetail = {
+  id: 10,
+  ticketNumber: "TK-000010",
+  requester,
+  category: { id: 1, name: "Hardware" },
+  relatedSystem: { id: 2, name: "Campus Wi-Fi" },
+  summary: "Laptop cannot connect",
+  description: "The laptop cannot connect to the campus Wi-Fi.",
+  priority: "High",
+  status: "New",
+  createdAt: "2026-09-01T10:00:00.000Z",
+  updatedAt: "2026-09-01T11:00:00.000Z",
+};
+
+describe("Ticket Detail", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows the selected ticket information and attachments", async () => {
+    vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket);
+    vi.spyOn(api, "getTicketAttachments").mockResolvedValue([
+      {
+        id: 5,
+        ticketId: 10,
+        originalFilename: "wifi-error.png",
+        mimeType: "image/png",
+        sizeBytes: 2048,
+        createdAt: "2026-09-01T10:05:00.000Z",
+        removedAt: null,
+        removalReason: null,
+      },
+    ]);
+
+    render(<TicketDetail requester={requester} ticketId={10} onBack={vi.fn()} />);
+
+    expect(await screen.findByText("TK-000010")).toBeInTheDocument();
+    expect(screen.getByText("Laptop cannot connect")).toBeInTheDocument();
+    expect(screen.getByText("wifi-error.png")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Download/i })).toHaveAttribute(
+      "href",
+      "http://localhost:3000/api/attachments/5/download?requesterId=1"
+    );
+  });
+
+  it("soft-removes an attachment after the requester gives a reason", async () => {
+    vi.spyOn(window, "prompt").mockReturnValue("Wrong file");
+    vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket);
+    vi.spyOn(api, "getTicketAttachments").mockResolvedValue([
+      {
+        id: 5,
+        ticketId: 10,
+        originalFilename: "old-file.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 1024,
+        createdAt: "2026-09-01T10:05:00.000Z",
+        removedAt: null,
+        removalReason: null,
+      },
+    ]);
+    vi.spyOn(api, "removeAttachment").mockResolvedValue({
+      id: 5,
+      ticketId: 10,
+      originalFilename: "old-file.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 1024,
+      createdAt: "2026-09-01T10:05:00.000Z",
+      removedAt: "2026-09-01T12:00:00.000Z",
+      removalReason: "Wrong file",
+    });
+
+    render(<TicketDetail requester={requester} ticketId={10} onBack={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Remove/i }));
+
+    await waitFor(() => {
+      expect(api.removeAttachment).toHaveBeenCalledWith(5, 1, "Wrong file");
+    });
+    expect(await screen.findByText(/Wrong file/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Download/i })).not.toBeInTheDocument();
+  });
+
+  it("returns to My Tickets when Back is clicked", async () => {
+    const onBack = vi.fn();
+    vi.spyOn(api, "getTicketDetail").mockResolvedValue(ticket);
+    vi.spyOn(api, "getTicketAttachments").mockResolvedValue([]);
+
+    render(<TicketDetail requester={requester} ticketId={10} onBack={onBack} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Back to My Tickets/i }));
+
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -121,3 +121,17 @@ AI helped organize the React form into loading, validation, submitting, failure,
 ### My Own Decision and Verification
 
 I kept the backend as the final authority for validation and used client-side validation only to give faster feedback. I kept the selected requester read-only in the form because it comes from the Development Requester selector. I will run the frontend and backend tests, build both projects, and manually create a ticket before opening the pull request.
+
+## Record 8 — Ticket Detail and Attachments
+
+### Prompt
+
+> Help me implement Issue #17: a Ticket Detail screen with requester-owned access, public attachment metadata, attachment download, soft removal with a reason, and tests.
+
+### How AI Helped
+
+AI helped separate the feature into backend ownership checks, safe attachment metadata responses, file download handling, soft-removal behaviour, a React Ticket Detail view, and automated tests.
+
+### My Own Decision and Verification
+
+I kept attachment metadata visible after removal because the lab requires soft removal instead of hard deletion. I also made sure the list response does not expose internal stored filenames or file paths. I will verify the feature with backend API tests, frontend component tests, TypeScript builds, and manual browser evidence before opening the pull request.

--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -357,6 +357,7 @@ Possible errors:
 - `400` when `attachmentId`, `X-Requester-Id`, or `removalReason` is missing or invalid.
 - `403` when the attachment belongs to another requester.
 - `404` when the attachment does not exist.
+- `409` when the attachment has already been soft-removed.
 - `500` with a safe message when the attachment cannot be removed.
 ## 7. Error Response Format
 

--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -265,6 +265,31 @@ The uploaded file field name is `file`.
 
 The API accepts JPG/JPEG, PNG, WEBP, and PDF files only. Each file must not be larger than 5 MB, and a ticket can have at most five active attachments.
 
+Success response `201`:
+
+```json
+{
+  "id": 3,
+  "ticketId": 1,
+  "originalFilename": "network-error.png",
+  "mimeType": "image/png",
+  "sizeBytes": 2048,
+  "createdAt": "2026-09-03T10:10:00.000Z",
+  "removedAt": null,
+  "removalReason": null
+}
+```
+
+Possible errors:
+
+- `400` when `ticketId`, `X-Requester-Id`, or the uploaded `file` field is missing or invalid.
+- `403` when the ticket belongs to another requester.
+- `404` when the ticket does not exist.
+- `409` when the ticket already has five active attachments.
+- `413` when the uploaded file is larger than 5 MB.
+- `415` when the uploaded file type is not JPG/JPEG, PNG, WEBP, or PDF.
+- `500` with a safe message when the attachment cannot be stored.
+
 ### GET /api/attachments/:attachmentId/download
 
 Downloads an active attachment only when its ticket belongs to the selected requester.

--- a/docs/lab-02/api-spec.md
+++ b/docs/lab-02/api-spec.md
@@ -198,14 +198,17 @@ Success response `200`:
   "summary": "Cannot connect to university Wi-Fi",
   "description": "My laptop cannot connect to the campus Wi-Fi since this morning.",
   "priority": "Medium",
-  "attachments": [],
-  "createdAt": "2026-09-03T10:00:00.000Z"
+  "createdAt": "2026-09-03T10:00:00.000Z",
+  "updatedAt": "2026-09-03T10:00:00.000Z"
 }
 ```
 
 Possible errors:
 
-- `404` when the ticket does not exist or does not belong to the selected requester.
+- `400` when `ticketId` or `X-Requester-Id` is missing or invalid.
+- `403` when the ticket belongs to another requester.
+- `404` when the ticket does not exist.
+- `500` with a safe message when the detail cannot be loaded.
 
 ## 6. Attachment APIs
 
@@ -220,6 +223,32 @@ X-Requester-Id: 1
 ```
 
 Removed attachments remain visible in this response as metadata, with a non-null `removedAt` value.
+
+Success response `200`:
+
+```json
+[
+  {
+    "id": 1,
+    "ticketId": 1,
+    "originalFilename": "network-error.png",
+    "mimeType": "image/png",
+    "sizeBytes": 2048,
+    "createdAt": "2026-09-03T10:05:00.000Z",
+    "removedAt": null,
+    "removalReason": null
+  }
+]
+```
+
+The response must not expose the internal stored filename or server file path.
+
+Possible errors:
+
+- `400` when `ticketId` or `X-Requester-Id` is missing or invalid.
+- `403` when the ticket belongs to another requester.
+- `404` when the ticket does not exist.
+- `500` with a safe message when the attachment list cannot be loaded.
 
 ### POST /api/tickets/:ticketId/attachments
 
@@ -242,6 +271,26 @@ Downloads an active attachment only when its ticket belongs to the selected requ
 
 The API must reject download when the attachment has been soft-removed.
 
+Request identity:
+
+```text
+X-Requester-Id: 1
+```
+
+For browser download links, the requester id may also be sent as a query string:
+
+```text
+GET /api/attachments/1/download?requesterId=1
+```
+
+Possible errors:
+
+- `400` when `attachmentId` or requester identity is missing or invalid.
+- `403` when the attachment belongs to another requester.
+- `404` when the attachment metadata or physical file cannot be found.
+- `410` when the attachment has been soft-removed.
+- `500` with a safe message when the file cannot be downloaded.
+
 ### DELETE /api/attachments/:attachmentId
 
 Soft-removes an active attachment only when its ticket belongs to the selected requester.
@@ -262,6 +311,28 @@ Request body:
 ```
 
 The API must keep the attachment metadata, set `removedAt`, save the removal reason, and block all future download or preview requests for that attachment.
+
+Success response `200` returns the public metadata for the removed attachment:
+
+```json
+{
+  "id": 1,
+  "ticketId": 1,
+  "originalFilename": "network-error.png",
+  "mimeType": "image/png",
+  "sizeBytes": 2048,
+  "createdAt": "2026-09-03T10:05:00.000Z",
+  "removedAt": "2026-09-03T10:10:00.000Z",
+  "removalReason": "Uploaded the wrong file"
+}
+```
+
+Possible errors:
+
+- `400` when `attachmentId`, `X-Requester-Id`, or `removalReason` is missing or invalid.
+- `403` when the attachment belongs to another requester.
+- `404` when the attachment does not exist.
+- `500` with a safe message when the attachment cannot be removed.
 ## 7. Error Response Format
 
 Validation and safe application errors use this format:

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -27,7 +27,7 @@ For each Lab 2 feature:
 | #14 | `feature/14-create-ticket-api` | To be added | mxckiexz | Implementation complete; awaiting PR |
 | #15 | `feature/15-create-ticket-ui` | To be added | To be added | Implementation complete; awaiting PR |
 | #16 | `feature/16-my-tickets` | To be added | mxckiexz | Implementation complete; awaiting PR |
-| #17 | `feature/17-ticket-detail-attachments` | To be added | To be added | Not started |
+| #17 | `feature/17-ticket-detail-attachments` | To be added | mxckiexz | Implementation in progress |
 | #18 | `feature/18-final-testing-release` | To be added | To be added | Not started |
 
 ## Reviewer Comments and My Responses
@@ -81,6 +81,22 @@ My response:
 Resolution:
 
 > The busy-state evidence is now covered by an automated test. Attachment implementation remains planned for Issue #17 before final PDF evidence is collected.
+
+### Issue #17 — Ticket Detail and Attachments
+
+Reviewer: mxckiexz
+
+Reviewer comment:
+
+> To be added after peer review.
+
+My response:
+
+> I implemented the Ticket Detail screen, ownership-scoped ticket detail API, attachment metadata list, attachment download, and attachment soft removal with a required removal reason. Removed attachments keep their metadata and cannot be downloaded again.
+
+Resolution:
+
+> Implementation is complete locally. Waiting for pull request review.
 
 ## Pull Requests I Reviewed for My Peer
 

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -98,6 +98,10 @@ Resolution:
 
 > Changes completed locally. Waiting for the reviewer to re-check the updated pull request.
 
+Follow-up review and response:
+
+> Repeat removal is now rejected with `409`, so the original removal reason cannot be overwritten. The upload body collector now stops buffering once it reaches a bounded multipart request limit, and API tests cover a file exactly at the 5 MB limit as well as an over-limit file. Replacing the small, scoped parser with a streaming library such as multer is deferred because it is a broader infrastructure change rather than a Lab 2 requirement.
+
 ## Pull Requests I Reviewed for My Peer
 
 | Peer repository / pull request | What I checked | My review result |

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -88,15 +88,15 @@ Reviewer: mxckiexz
 
 Reviewer comment:
 
-> To be added after peer review.
+> POST `/api/tickets/:ticketId/attachments` must exist in the backend with type, size, and count validation. Ticket Detail or Create Ticket must include a real file picker and upload UI. tests.md and ui-spec.md must not mark AC-07 as passed until upload is actually tested.
 
 My response:
 
-> I implemented the Ticket Detail screen, ownership-scoped ticket detail API, attachment metadata list, attachment download, and attachment soft removal with a required removal reason. Removed attachments keep their metadata and cannot be downloaded again.
+> I added the real backend upload endpoint for ticket attachments with requester ownership, allowed file type, 5 MB size, and five-active-file limit validation. I added the Ticket Detail upload picker, client-side validation, upload success/error states, list refresh after upload, and disabled state at the five-file limit. I also updated api-spec.md, ui-spec.md, and tests.md so AC-07 is marked passed only with backend and frontend upload tests.
 
 Resolution:
 
-> Implementation is complete locally. Waiting for pull request review.
+> Changes completed locally. Waiting for the reviewer to re-check the updated pull request.
 
 ## Pull Requests I Reviewed for My Peer
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -21,13 +21,13 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 | API-03B | API Boundary | AC-03, BR-04 | Summary and description length limits | Accepts 100-character summaries and 2,000-character descriptions; rejects 101-character summaries and 2,001-character descriptions with `400` | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
 | API-04 | API | AC-04 | Active reference validation | Rejects inactive references with `400` and missing references with `404` | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
 | API-05 | API | AC-05 | My Tickets query behaviour | Returns requester-owned tickets newest-first by default, supports search and combined filters, and rejects invalid requester or paging input | `server/tests/lab-02/my-tickets.api.test.ts` | Passed |
-| API-06 | API | AC-06 | Ticket ownership | Rejects another requester trying to read ticket detail | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
-| API-07 | API | AC-07 | Attachment upload | Accepts allowed files within size and active-count limits | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| API-08 | API | AC-08 | Attachment soft removal | Stores `removedAt` and removal reason, retains metadata, and blocks download | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-06 | API | AC-06 | Ticket detail ownership | Returns a ticket detail only for the owner and rejects another requester with `403` | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
+| API-07 | API | AC-07 | Attachment inspection and download | Lists public attachment metadata and downloads active files only for the ticket owner | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
+| API-08 | API | AC-08 | Attachment soft removal | Stores `removedAt` and removal reason, retains metadata, and blocks download with `410` | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
 | UI-01 | UI Component | AC-01 | Development Requester selector | Displays active requesters and saves the selected requester | `client/tests/lab-02/RequesterSelector.test.tsx` | Passed |
 | UI-02 | UI Component | AC-02, AC-03 | Create Ticket form and validation | Loads active reference data, shows field messages without calling the API when invalid, submits the selected requester, shows a disabled `Submitting...` state while waiting, and keeps data after an API error | `client/tests/lab-02/CreateTicket.test.tsx` | Passed |
 | UI-03 | UI Component | AC-05 | My Tickets screen | Displays a requester-owned ticket list, filter controls, and a helpful empty state | `client/tests/lab-02/MyTickets.test.tsx` | Passed |
-| UI-04 | UI Component | AC-08 | Attachment section | Shows active and removed attachment states and confirms removal reason | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
+| UI-04 | UI Component | AC-06, AC-07, AC-08 | Ticket Detail and attachment section | Opens a ticket detail screen, shows active and removed attachment states, provides download links, and confirms removal reason before soft removal | `client/tests/lab-02/TicketDetail.test.tsx` | Passed |
 | STYLE-01 | UI Style | AC-09 | Zen Green design tokens | Uses the documented design tokens, required labels, field-level validation placement, and a busy submit state | `client/tests/lab-02/CreateTicket.test.tsx` | Passed |
 | RESPONSIVE-01 | Responsive | AC-09 | Responsive layouts | Checks desktop, tablet, and mobile screenshots for clipping or overflow | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
 | E2E-01 | End-to-end | AC-02, AC-05, AC-06 | Requester ticket flow | Requester A creates and finds a ticket; Requester B cannot access it | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
@@ -43,8 +43,8 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 | AC-03 — Ticket Validation | API-03, API-03B, UI-02 | Passing tests and validation-message screenshot |
 | AC-04 — Active Reference Validation | DB-01, API-04 | Seed-data test and passing API test output |
 | AC-05 — Requester-Owned Ticket List | API-05, UI-03, E2E-01 | My Tickets screenshot with search, filters, sorting, and pagination |
-| AC-06 — Ownership Protection | API-06, E2E-01 | Passing API test and cross-requester access evidence |
-| AC-07 — Upload Attachment | API-07, E2E-02 | Passing test and uploaded attachment screenshot |
+| AC-06 — Ownership Protection | API-06, UI-04, E2E-01 | Passing API test, Ticket Detail screenshot, and cross-requester access evidence |
+| AC-07 — Upload/View/Download Attachment | API-07, UI-04, E2E-02 | Attachment metadata list, download link, and uploaded attachment screenshot |
 | AC-08 — Soft-Remove Attachment | API-08, UI-04, E2E-02 | Removed metadata, removal reason, and blocked-download evidence |
 | AC-09 — Responsive Zen Green UI | STYLE-01, RESPONSIVE-01 | Desktop, tablet, and mobile screenshots plus visual checklist |
 
@@ -120,6 +120,13 @@ Issue #15 verification results:
 - UI-02 verifies client-side required-field validation, successful submission using the selected requester, a disabled `Submitting...` state while the API request is pending, and preserving entered data after an API error.
 - STYLE-01 verifies the Create Ticket form uses the documented Zen Green UI classes, field labels, error placement, and the busy submit state covered by UI-02.
 - The form reads active categories and related systems, while the backend also validates those values before creating a ticket.
+
+Issue #17 verification results:
+
+- API-06 verifies that a requester can open their own ticket detail and that another requester receives `403`.
+- API-07 verifies that attachment metadata is public-safe, active attachments can be downloaded by the owner, and another requester cannot download them.
+- API-08 verifies soft removal by saving `removedAt` and `removalReason`, keeping the metadata row, and blocking future downloads with `410`.
+- UI-04 verifies the Ticket Detail screen, attachment list, download link, soft-remove prompt, removed state, and Back navigation from detail to My Tickets.
 
 Final submission evidence must show that all required tests pass and that no required test is skipped, disabled, or commented out.
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -22,12 +22,13 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 | API-04 | API | AC-04 | Active reference validation | Rejects inactive references with `400` and missing references with `404` | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
 | API-05 | API | AC-05 | My Tickets query behaviour | Returns requester-owned tickets newest-first by default, supports search and combined filters, and rejects invalid requester or paging input | `server/tests/lab-02/my-tickets.api.test.ts` | Passed |
 | API-06 | API | AC-06 | Ticket detail ownership | Returns a ticket detail only for the owner and rejects another requester with `403` | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
-| API-07 | API | AC-07 | Attachment inspection and download | Lists public attachment metadata and downloads active files only for the ticket owner | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
+| API-07 | API | AC-07, BR-08, BR-09 | Attachment upload validation | Uploads permitted files for the ticket owner and rejects unsupported type, over-size, over-count, and non-owner upload attempts | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
+| API-07B | API | AC-07 | Attachment inspection and download | Lists public attachment metadata and downloads active files only for the ticket owner | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
 | API-08 | API | AC-08 | Attachment soft removal | Stores `removedAt` and removal reason, retains metadata, and blocks download with `410` | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
 | UI-01 | UI Component | AC-01 | Development Requester selector | Displays active requesters and saves the selected requester | `client/tests/lab-02/RequesterSelector.test.tsx` | Passed |
 | UI-02 | UI Component | AC-02, AC-03 | Create Ticket form and validation | Loads active reference data, shows field messages without calling the API when invalid, submits the selected requester, shows a disabled `Submitting...` state while waiting, and keeps data after an API error | `client/tests/lab-02/CreateTicket.test.tsx` | Passed |
 | UI-03 | UI Component | AC-05 | My Tickets screen | Displays a requester-owned ticket list, filter controls, and a helpful empty state | `client/tests/lab-02/MyTickets.test.tsx` | Passed |
-| UI-04 | UI Component | AC-06, AC-07, AC-08 | Ticket Detail and attachment section | Opens a ticket detail screen, shows active and removed attachment states, provides download links, and confirms removal reason before soft removal | `client/tests/lab-02/TicketDetail.test.tsx` | Passed |
+| UI-04 | UI Component | AC-06, AC-07, AC-08 | Ticket Detail and attachment section | Opens a ticket detail screen, uploads a selected attachment, blocks unsupported files, disables upload at five active attachments, shows active and removed attachment states, provides download links, and confirms removal reason before soft removal | `client/tests/lab-02/TicketDetail.test.tsx` | Passed |
 | STYLE-01 | UI Style | AC-09 | Zen Green design tokens | Uses the documented design tokens, required labels, field-level validation placement, and a busy submit state | `client/tests/lab-02/CreateTicket.test.tsx` | Passed |
 | RESPONSIVE-01 | Responsive | AC-09 | Responsive layouts | Checks desktop, tablet, and mobile screenshots for clipping or overflow | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
 | E2E-01 | End-to-end | AC-02, AC-05, AC-06 | Requester ticket flow | Requester A creates and finds a ticket; Requester B cannot access it | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
@@ -44,7 +45,7 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 | AC-04 — Active Reference Validation | DB-01, API-04 | Seed-data test and passing API test output |
 | AC-05 — Requester-Owned Ticket List | API-05, UI-03, E2E-01 | My Tickets screenshot with search, filters, sorting, and pagination |
 | AC-06 — Ownership Protection | API-06, UI-04, E2E-01 | Passing API test, Ticket Detail screenshot, and cross-requester access evidence |
-| AC-07 — Upload/View/Download Attachment | API-07, UI-04, E2E-02 | Attachment metadata list, download link, and uploaded attachment screenshot |
+| AC-07 — Upload/View/Download Attachment | API-07, API-07B, UI-04, E2E-02 | Upload test output, attachment metadata list, download link, and uploaded attachment screenshot |
 | AC-08 — Soft-Remove Attachment | API-08, UI-04, E2E-02 | Removed metadata, removal reason, and blocked-download evidence |
 | AC-09 — Responsive Zen Green UI | STYLE-01, RESPONSIVE-01 | Desktop, tablet, and mobile screenshots plus visual checklist |
 
@@ -124,9 +125,10 @@ Issue #15 verification results:
 Issue #17 verification results:
 
 - API-06 verifies that a requester can open their own ticket detail and that another requester receives `403`.
-- API-07 verifies that attachment metadata is public-safe, active attachments can be downloaded by the owner, and another requester cannot download them.
+- API-07 verifies that the owner can upload allowed attachments and that unsupported type, over-size, over-count, and non-owner upload attempts are rejected.
+- API-07B verifies that attachment metadata is public-safe, active attachments can be downloaded by the owner, and another requester cannot download them.
 - API-08 verifies soft removal by saving `removedAt` and `removalReason`, keeping the metadata row, and blocking future downloads with `410`.
-- UI-04 verifies the Ticket Detail screen, attachment list, download link, soft-remove prompt, removed state, and Back navigation from detail to My Tickets.
+- UI-04 verifies the Ticket Detail screen, attachment upload picker, successful upload refresh, unsupported-file validation, five-file disabled state, attachment list, download link, soft-remove prompt, removed state, and Back navigation from detail to My Tickets.
 
 Final submission evidence must show that all required tests pass and that no required test is skipped, disabled, or commented out.
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -22,9 +22,9 @@ Lab 2 uses unit, API/integration, UI component, UI style, responsive, and end-to
 | API-04 | API | AC-04 | Active reference validation | Rejects inactive references with `400` and missing references with `404` | `server/tests/lab-02/create-ticket.api.test.ts` | Passed |
 | API-05 | API | AC-05 | My Tickets query behaviour | Returns requester-owned tickets newest-first by default, supports search and combined filters, and rejects invalid requester or paging input | `server/tests/lab-02/my-tickets.api.test.ts` | Passed |
 | API-06 | API | AC-06 | Ticket detail ownership | Returns a ticket detail only for the owner and rejects another requester with `403` | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
-| API-07 | API | AC-07, BR-08, BR-09 | Attachment upload validation | Uploads permitted files for the ticket owner and rejects unsupported type, over-size, over-count, and non-owner upload attempts | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
+| API-07 | API | AC-07, BR-08, BR-09 | Attachment upload validation | Uploads permitted files for the ticket owner, accepts a file exactly 5 MB, and rejects unsupported type, over-size, over-count, and non-owner upload attempts | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
 | API-07B | API | AC-07 | Attachment inspection and download | Lists public attachment metadata and downloads active files only for the ticket owner | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
-| API-08 | API | AC-08 | Attachment soft removal | Stores `removedAt` and removal reason, retains metadata, and blocks download with `410` | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
+| API-08 | API | AC-08 | Attachment soft removal | Stores `removedAt` and removal reason once, retains metadata, rejects repeat removal with `409`, and blocks download with `410` | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Passed |
 | UI-01 | UI Component | AC-01 | Development Requester selector | Displays active requesters and saves the selected requester | `client/tests/lab-02/RequesterSelector.test.tsx` | Passed |
 | UI-02 | UI Component | AC-02, AC-03 | Create Ticket form and validation | Loads active reference data, shows field messages without calling the API when invalid, submits the selected requester, shows a disabled `Submitting...` state while waiting, and keeps data after an API error | `client/tests/lab-02/CreateTicket.test.tsx` | Passed |
 | UI-03 | UI Component | AC-05 | My Tickets screen | Displays a requester-owned ticket list, filter controls, and a helpful empty state | `client/tests/lab-02/MyTickets.test.tsx` | Passed |
@@ -125,9 +125,9 @@ Issue #15 verification results:
 Issue #17 verification results:
 
 - API-06 verifies that a requester can open their own ticket detail and that another requester receives `403`.
-- API-07 verifies that the owner can upload allowed attachments and that unsupported type, over-size, over-count, and non-owner upload attempts are rejected.
+- API-07 verifies that the owner can upload allowed attachments at or below the 5 MB limit and that unsupported type, over-size, over-count, and non-owner upload attempts are rejected.
 - API-07B verifies that attachment metadata is public-safe, active attachments can be downloaded by the owner, and another requester cannot download them.
-- API-08 verifies soft removal by saving `removedAt` and `removalReason`, keeping the metadata row, and blocking future downloads with `410`.
+- API-08 verifies soft removal by saving `removedAt` and `removalReason` once, keeping the metadata row, rejecting repeat removal with `409`, and blocking future downloads with `410`.
 - UI-04 verifies the Ticket Detail screen, attachment upload picker, successful upload refresh, unsupported-file validation, five-file disabled state, attachment list, download link, soft-remove prompt, removed state, and Back navigation from detail to My Tickets.
 
 Final submission evidence must show that all required tests pass and that no required test is skipped, disabled, or commented out.

--- a/docs/lab-02/ui-spec.md
+++ b/docs/lab-02/ui-spec.md
@@ -120,13 +120,16 @@ The page should show:
 
 The attachment section should allow the ticket owner to:
 
+- Select and upload one new attachment
+- See the active attachment count out of the five-file limit
+- See a clear validation message for unsupported files, files over 5 MB, or count-limit failures
 - View attachment name, size, and upload date
 - Download an active attachment
 - Start a soft-removal action for an active attachment
 - Enter a required removal reason
 - Confirm the soft-removal action
 
-Uploading a new attachment from an existing ticket detail page is handled in the later attachment-add flow. This page must still display existing attachments correctly and protect all download and soft-removal actions by requester ownership.
+The upload picker must accept only JPG/JPEG, PNG, WEBP, and PDF files. It must be disabled when the ticket already has five active attachments. After a successful upload, the file input clears and the attachment list refreshes from the API so the displayed metadata comes from the backend.
 
 A removed attachment must remain visible as metadata with a clear `Removed` state, removed date, and removal reason. Its download and preview actions must be disabled or hidden.
 

--- a/docs/lab-02/ui-spec.md
+++ b/docs/lab-02/ui-spec.md
@@ -120,12 +120,13 @@ The page should show:
 
 The attachment section should allow the ticket owner to:
 
-- Select and upload an allowed file
 - View attachment name, size, and upload date
 - Download an active attachment
 - Start a soft-removal action for an active attachment
 - Enter a required removal reason
 - Confirm the soft-removal action
+
+Uploading a new attachment from an existing ticket detail page is handled in the later attachment-add flow. This page must still display existing attachments correctly and protect all download and soft-removal actions by requester ownership.
 
 A removed attachment must remain visible as metadata with a clear `Removed` state, removed date, and removal reason. Its download and preview actions must be disabled or hidden.
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -112,6 +112,7 @@ const priorityValues: Record<string, Priority> = {
 
 const duplicateWindowMs = 60_000;
 const maxAttachmentSizeBytes = 5 * 1024 * 1024;
+const maxMultipartRequestBytes = maxAttachmentSizeBytes + 1024 * 1024;
 const maxActiveAttachmentsPerTicket = 5;
 const allowedAttachmentMimeTypes = new Set([
   "image/jpeg",
@@ -125,6 +126,8 @@ interface UploadedMultipartFile {
   mimeType: string;
   bytes: Buffer;
 }
+
+class RequestBodyTooLargeError extends Error {}
 
 function positiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0;
@@ -211,12 +214,27 @@ function multipartBoundary(req: Request) {
   return boundaryMatch?.[1] ?? boundaryMatch?.[2];
 }
 
-function collectRequestBody(req: Request): Promise<Buffer> {
+function collectRequestBody(req: Request, maxBytes: number): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
+    let receivedBytes = 0;
+    let exceededLimit = false;
 
     req.on("data", (chunk: Buffer | string) => {
-      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      if (exceededLimit) {
+        return;
+      }
+
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      receivedBytes += buffer.length;
+
+      if (receivedBytes > maxBytes) {
+        exceededLimit = true;
+        reject(new RequestBodyTooLargeError());
+        return;
+      }
+
+      chunks.push(buffer);
     });
     req.on("end", () => resolve(Buffer.concat(chunks)));
     req.on("error", reject);
@@ -602,7 +620,7 @@ app.post("/api/tickets/:ticketId/attachments", async (req: Request, res: Respons
   }
 
   try {
-    const uploadedFile = parseMultipartFile(req, await collectRequestBody(req));
+    const uploadedFile = parseMultipartFile(req, await collectRequestBody(req, maxMultipartRequestBytes));
 
     if (!uploadedFile || uploadedFile.bytes.length === 0) {
       return res.status(400).json({ message: "A file is required" });
@@ -670,7 +688,11 @@ app.post("/api/tickets/:ticketId/attachments", async (req: Request, res: Respons
     });
 
     return res.status(201).json(attachmentResponse(attachment));
-  } catch {
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return res.status(413).json({ message: "Attachment must not exceed 5 MB" });
+    }
+
     return res.status(500).json({ message: "Unable to upload attachment" });
   }
 });
@@ -753,10 +775,14 @@ app.delete("/api/attachments/:attachmentId", async (req: Request, res: Response)
       return res.status(403).json({ message: "You can only remove your own attachments" });
     }
 
+    if (attachment.removedAt) {
+      return res.status(409).json({ message: "This attachment has already been removed" });
+    }
+
     const updatedAttachment = await prisma.attachment.update({
       where: { id: attachmentId },
       data: {
-        removedAt: attachment.removedAt ?? new Date(),
+        removedAt: new Date(),
         removalReason,
       },
       select: {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,8 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import { Prisma, Priority } from "@prisma/client";
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import path from "node:path";
 import { getPrisma } from "./prisma.js";
 import { generateTicketNumber } from "./ticket-number.js";
 
@@ -114,6 +116,10 @@ function positiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0;
 }
 
+function formatPriority(priority: Priority) {
+  return priority[0] + priority.slice(1).toLowerCase();
+}
+
 function createTicketResponse(ticket: {
   id: number;
   ticketNumber: string;
@@ -135,7 +141,7 @@ function createTicketResponse(ticket: {
     relatedSystemId: ticket.relatedSystemId,
     summary: ticket.summary,
     description: ticket.description,
-    priority: ticket.priority[0] + ticket.priority.slice(1).toLowerCase(),
+    priority: formatPriority(ticket.priority),
     createdAt: ticket.createdAt,
   };
 }
@@ -150,6 +156,33 @@ function queryPositiveInteger(value: unknown): number | undefined {
 
   const parsed = Number(text);
   return positiveInteger(parsed) ? parsed : undefined;
+}
+
+function requesterIdFromHeader(req: Request): number | undefined {
+  const requesterId = Number(req.header("X-Requester-Id"));
+  return positiveInteger(requesterId) ? requesterId : undefined;
+}
+
+function attachmentResponse(attachment: {
+  id: number;
+  ticketId: number;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: Date;
+  removedAt: Date | null;
+  removalReason: string | null;
+}) {
+  return {
+    id: attachment.id,
+    ticketId: attachment.ticketId,
+    originalFilename: attachment.originalFilename,
+    mimeType: attachment.mimeType,
+    sizeBytes: attachment.sizeBytes,
+    createdAt: attachment.createdAt,
+    removedAt: attachment.removedAt,
+    removalReason: attachment.removalReason,
+  };
 }
 
 app.post("/api/tickets", async (req: Request, res: Response) => {
@@ -372,7 +405,7 @@ app.get("/api/tickets", async (req: Request, res: Response) => {
         id: ticket.id,
         ticketNumber: ticket.ticketNumber,
         summary: ticket.summary,
-        priority: ticket.priority[0] + ticket.priority.slice(1).toLowerCase(),
+        priority: formatPriority(ticket.priority),
         status: ticket.currentStatus,
         category: ticket.category,
         relatedSystem: ticket.relatedSystem,
@@ -385,6 +418,206 @@ app.get("/api/tickets", async (req: Request, res: Response) => {
     });
   } catch {
     return res.status(500).json({ message: "Unable to load tickets" });
+  }
+});
+
+// Lab 2, Issue 17 - Ticket detail and attachment inspection
+app.get("/api/tickets/:ticketId", async (req: Request, res: Response) => {
+  const requesterId = requesterIdFromHeader(req);
+  const ticketId = Number(req.params.ticketId);
+
+  if (!requesterId) {
+    return res.status(400).json({ message: "A valid X-Requester-Id is required" });
+  }
+
+  if (!positiveInteger(ticketId)) {
+    return res.status(400).json({ message: "A valid ticket id is required" });
+  }
+
+  try {
+    const prisma = getPrisma();
+    const ticket = await prisma.ticket.findUnique({
+      where: { id: ticketId },
+      include: {
+        requester: { select: { id: true, name: true, email: true } },
+        category: { select: { id: true, name: true } },
+        relatedSystem: { select: { id: true, name: true } },
+      },
+    });
+
+    if (!ticket) {
+      return res.status(404).json({ message: "Ticket was not found" });
+    }
+
+    if (ticket.requesterId !== requesterId) {
+      return res.status(403).json({ message: "You can only view your own tickets" });
+    }
+
+    return res.status(200).json({
+      id: ticket.id,
+      ticketNumber: ticket.ticketNumber,
+      requester: ticket.requester,
+      category: ticket.category,
+      relatedSystem: ticket.relatedSystem,
+      summary: ticket.summary,
+      description: ticket.description,
+      priority: formatPriority(ticket.priority),
+      status: ticket.currentStatus,
+      createdAt: ticket.createdAt,
+      updatedAt: ticket.updatedAt,
+    });
+  } catch {
+    return res.status(500).json({ message: "Unable to load ticket details" });
+  }
+});
+
+app.get("/api/tickets/:ticketId/attachments", async (req: Request, res: Response) => {
+  const requesterId = requesterIdFromHeader(req);
+  const ticketId = Number(req.params.ticketId);
+
+  if (!requesterId) {
+    return res.status(400).json({ message: "A valid X-Requester-Id is required" });
+  }
+
+  if (!positiveInteger(ticketId)) {
+    return res.status(400).json({ message: "A valid ticket id is required" });
+  }
+
+  try {
+    const prisma = getPrisma();
+    const ticket = await prisma.ticket.findUnique({
+      where: { id: ticketId },
+      select: { requesterId: true },
+    });
+
+    if (!ticket) {
+      return res.status(404).json({ message: "Ticket was not found" });
+    }
+
+    if (ticket.requesterId !== requesterId) {
+      return res.status(403).json({ message: "You can only view attachments for your own tickets" });
+    }
+
+    const attachments = await prisma.attachment.findMany({
+      where: { ticketId },
+      select: {
+        id: true,
+        ticketId: true,
+        originalFilename: true,
+        mimeType: true,
+        sizeBytes: true,
+        createdAt: true,
+        removedAt: true,
+        removalReason: true,
+      },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    });
+
+    return res.status(200).json(attachments.map(attachmentResponse));
+  } catch {
+    return res.status(500).json({ message: "Unable to load attachments" });
+  }
+});
+
+app.get("/api/attachments/:attachmentId/download", async (req: Request, res: Response) => {
+  const requesterId = requesterIdFromHeader(req) ?? queryPositiveInteger(req.query.requesterId);
+  const attachmentId = Number(req.params.attachmentId);
+
+  if (!requesterId) {
+    return res.status(400).json({ message: "A valid X-Requester-Id is required" });
+  }
+
+  if (!positiveInteger(attachmentId)) {
+    return res.status(400).json({ message: "A valid attachment id is required" });
+  }
+
+  try {
+    const prisma = getPrisma();
+    const attachment = await prisma.attachment.findUnique({
+      where: { id: attachmentId },
+      include: { ticket: { select: { requesterId: true } } },
+    });
+
+    if (!attachment) {
+      return res.status(404).json({ message: "Attachment was not found" });
+    }
+
+    if (attachment.ticket.requesterId !== requesterId) {
+      return res.status(403).json({ message: "You can only download your own attachments" });
+    }
+
+    if (attachment.removedAt) {
+      return res.status(410).json({ message: "This attachment has been removed" });
+    }
+
+    const uploadRoot = path.resolve(process.cwd(), "uploads");
+    const filePath = path.resolve(uploadRoot, attachment.storedFilename);
+
+    if (!filePath.startsWith(uploadRoot) || !existsSync(filePath)) {
+      return res.status(404).json({ message: "Attachment file was not found" });
+    }
+
+    res.setHeader("Content-Type", attachment.mimeType);
+    res.setHeader("Content-Disposition", `attachment; filename="${attachment.originalFilename.replaceAll('"', "")}"`);
+    return res.sendFile(filePath);
+  } catch {
+    return res.status(500).json({ message: "Unable to download attachment" });
+  }
+});
+
+app.delete("/api/attachments/:attachmentId", async (req: Request, res: Response) => {
+  const requesterId = requesterIdFromHeader(req);
+  const attachmentId = Number(req.params.attachmentId);
+  const removalReason = typeof req.body?.removalReason === "string" ? req.body.removalReason.trim() : "";
+
+  if (!requesterId) {
+    return res.status(400).json({ message: "A valid X-Requester-Id is required" });
+  }
+
+  if (!positiveInteger(attachmentId)) {
+    return res.status(400).json({ message: "A valid attachment id is required" });
+  }
+
+  if (!removalReason) {
+    return res.status(400).json({ message: "A removal reason is required" });
+  }
+
+  try {
+    const prisma = getPrisma();
+    const attachment = await prisma.attachment.findUnique({
+      where: { id: attachmentId },
+      include: { ticket: { select: { requesterId: true } } },
+    });
+
+    if (!attachment) {
+      return res.status(404).json({ message: "Attachment was not found" });
+    }
+
+    if (attachment.ticket.requesterId !== requesterId) {
+      return res.status(403).json({ message: "You can only remove your own attachments" });
+    }
+
+    const updatedAttachment = await prisma.attachment.update({
+      where: { id: attachmentId },
+      data: {
+        removedAt: attachment.removedAt ?? new Date(),
+        removalReason,
+      },
+      select: {
+        id: true,
+        ticketId: true,
+        originalFilename: true,
+        mimeType: true,
+        sizeBytes: true,
+        createdAt: true,
+        removedAt: true,
+        removalReason: true,
+      },
+    });
+
+    return res.status(200).json(attachmentResponse(updatedAttachment));
+  } catch {
+    return res.status(500).json({ message: "Unable to remove attachment" });
   }
 });
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import { Prisma, Priority } from "@prisma/client";
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { getPrisma } from "./prisma.js";
 import { generateTicketNumber } from "./ticket-number.js";
@@ -111,6 +111,20 @@ const priorityValues: Record<string, Priority> = {
 };
 
 const duplicateWindowMs = 60_000;
+const maxAttachmentSizeBytes = 5 * 1024 * 1024;
+const maxActiveAttachmentsPerTicket = 5;
+const allowedAttachmentMimeTypes = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+]);
+
+interface UploadedMultipartFile {
+  originalFilename: string;
+  mimeType: string;
+  bytes: Buffer;
+}
 
 function positiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0;
@@ -183,6 +197,62 @@ function attachmentResponse(attachment: {
     removedAt: attachment.removedAt,
     removalReason: attachment.removalReason,
   };
+}
+
+function safeOriginalFilename(filename: string) {
+  const baseName = path.basename(filename).trim();
+  const cleaned = baseName.replace(/[^\w .()-]/g, "_");
+  return cleaned || "attachment";
+}
+
+function multipartBoundary(req: Request) {
+  const contentType = req.header("content-type") ?? "";
+  const boundaryMatch = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/i);
+  return boundaryMatch?.[1] ?? boundaryMatch?.[2];
+}
+
+function collectRequestBody(req: Request): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+
+    req.on("data", (chunk: Buffer | string) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function parseMultipartFile(req: Request, body: Buffer): UploadedMultipartFile | undefined {
+  const boundary = multipartBoundary(req);
+  if (!boundary) return undefined;
+
+  const bodyText = body.toString("latin1");
+  const parts = bodyText.split(`--${boundary}`);
+
+  for (const part of parts) {
+    if (!part.includes('name="file"')) continue;
+
+    const [rawHeaders, ...contentParts] = part.split("\r\n\r\n");
+    if (!rawHeaders || contentParts.length === 0) return undefined;
+
+    const filenameMatch = rawHeaders.match(/filename="([^"]*)"/i);
+    const typeMatch = rawHeaders.match(/content-type:\s*([^\r\n]+)/i);
+    const submittedFilename = filenameMatch?.[1]?.trim() ?? "";
+    if (!submittedFilename) return undefined;
+
+    const originalFilename = safeOriginalFilename(submittedFilename);
+    const mimeType = typeMatch?.[1]?.trim().toLowerCase() ?? "application/octet-stream";
+    const contentText = contentParts.join("\r\n\r\n").replace(/\r\n$/, "");
+
+    return {
+      originalFilename,
+      mimeType,
+      bytes: Buffer.from(contentText, "latin1"),
+    };
+  }
+
+  return undefined;
 }
 
 app.post("/api/tickets", async (req: Request, res: Response) => {
@@ -516,6 +586,92 @@ app.get("/api/tickets/:ticketId/attachments", async (req: Request, res: Response
     return res.status(200).json(attachments.map(attachmentResponse));
   } catch {
     return res.status(500).json({ message: "Unable to load attachments" });
+  }
+});
+
+app.post("/api/tickets/:ticketId/attachments", async (req: Request, res: Response) => {
+  const requesterId = requesterIdFromHeader(req);
+  const ticketId = Number(req.params.ticketId);
+
+  if (!requesterId) {
+    return res.status(400).json({ message: "A valid X-Requester-Id is required" });
+  }
+
+  if (!positiveInteger(ticketId)) {
+    return res.status(400).json({ message: "A valid ticket id is required" });
+  }
+
+  try {
+    const uploadedFile = parseMultipartFile(req, await collectRequestBody(req));
+
+    if (!uploadedFile || uploadedFile.bytes.length === 0) {
+      return res.status(400).json({ message: "A file is required" });
+    }
+
+    if (!allowedAttachmentMimeTypes.has(uploadedFile.mimeType)) {
+      return res.status(415).json({
+        message: "Unsupported attachment type. Use JPG, PNG, WEBP, or PDF.",
+      });
+    }
+
+    if (uploadedFile.bytes.length > maxAttachmentSizeBytes) {
+      return res.status(413).json({ message: "Attachment must not exceed 5 MB" });
+    }
+
+    const prisma = getPrisma();
+    const ticket = await prisma.ticket.findUnique({
+      where: { id: ticketId },
+      select: { requesterId: true },
+    });
+
+    if (!ticket) {
+      return res.status(404).json({ message: "Ticket was not found" });
+    }
+
+    if (ticket.requesterId !== requesterId) {
+      return res.status(403).json({ message: "You can only upload attachments to your own tickets" });
+    }
+
+    const activeAttachmentCount = await prisma.attachment.count({
+      where: {
+        ticketId,
+        removedAt: null,
+      },
+    });
+
+    if (activeAttachmentCount >= maxActiveAttachmentsPerTicket) {
+      return res.status(409).json({ message: "A ticket can have at most five active attachments" });
+    }
+
+    const uploadRoot = path.resolve(process.cwd(), "uploads");
+    mkdirSync(uploadRoot, { recursive: true });
+
+    const storedFilename = `${randomUUID()}-${uploadedFile.originalFilename}`;
+    writeFileSync(path.join(uploadRoot, storedFilename), uploadedFile.bytes);
+
+    const attachment = await prisma.attachment.create({
+      data: {
+        ticketId,
+        originalFilename: uploadedFile.originalFilename,
+        storedFilename,
+        mimeType: uploadedFile.mimeType,
+        sizeBytes: uploadedFile.bytes.length,
+      },
+      select: {
+        id: true,
+        ticketId: true,
+        originalFilename: true,
+        mimeType: true,
+        sizeBytes: true,
+        createdAt: true,
+        removedAt: true,
+        removalReason: true,
+      },
+    });
+
+    return res.status(201).json(attachmentResponse(attachment));
+  } catch {
+    return res.status(500).json({ message: "Unable to upload attachment" });
   }
 });
 

--- a/server/tests/lab-02/ticket-detail-attachments.api.test.ts
+++ b/server/tests/lab-02/ticket-detail-attachments.api.test.ts
@@ -1,0 +1,172 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { Priority } from "@prisma/client";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+
+const prisma = getPrisma();
+const marker = `Feature 17 automated test ${Date.now()}`;
+const uploadDir = path.resolve(process.cwd(), "uploads");
+const storedFilename = `feature-17-${Date.now()}.txt`;
+const fileBytes = Buffer.from("TokTickIT attachment download test");
+
+let ownerId: number;
+let otherRequesterId: number;
+let ticketId: number;
+let attachmentId: number;
+let removedAttachmentId: number;
+
+beforeAll(async () => {
+  const [owner, other, category, relatedSystem] = await Promise.all([
+    prisma.requester.findFirstOrThrow({ where: { isActive: true }, orderBy: { id: "asc" } }),
+    prisma.requester.findFirstOrThrow({ where: { isActive: true }, orderBy: { id: "desc" } }),
+    prisma.category.findFirstOrThrow({ where: { isActive: true }, orderBy: { id: "asc" } }),
+    prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true }, orderBy: { id: "asc" } }),
+  ]);
+
+  ownerId = owner.id;
+  otherRequesterId = other.id === owner.id ? owner.id + 1000 : other.id;
+
+  const ticket = await prisma.ticket.create({
+    data: {
+      ticketNumber: `TK-F17-${Date.now()}`,
+      requesterId: ownerId,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+      summary: `${marker} ticket detail`,
+      description: "Created only for ticket detail attachment tests.",
+      priority: Priority.HIGH,
+      currentStatus: "New",
+    },
+  });
+  ticketId = ticket.id;
+
+  mkdirSync(uploadDir, { recursive: true });
+  writeFileSync(path.join(uploadDir, storedFilename), fileBytes);
+
+  const activeAttachment = await prisma.attachment.create({
+    data: {
+      ticketId,
+      originalFilename: "network evidence.txt",
+      storedFilename,
+      mimeType: "text/plain",
+      sizeBytes: fileBytes.length,
+    },
+  });
+  attachmentId = activeAttachment.id;
+
+  const removedAttachment = await prisma.attachment.create({
+    data: {
+      ticketId,
+      originalFilename: "old evidence.pdf",
+      storedFilename: `removed-${storedFilename}`,
+      mimeType: "application/pdf",
+      sizeBytes: 100,
+      removedAt: new Date(),
+      removalReason: "Wrong file",
+    },
+  });
+  removedAttachmentId = removedAttachment.id;
+});
+
+afterAll(async () => {
+  await prisma.attachment.deleteMany({ where: { ticketId } });
+  await prisma.ticket.deleteMany({ where: { id: ticketId } });
+
+  try {
+    unlinkSync(path.join(uploadDir, storedFilename));
+  } catch {
+    // Test cleanup should not fail if the file was already removed manually.
+  }
+
+  await prisma.$disconnect();
+});
+
+describe("Ticket detail and attachments", () => {
+  it("returns one ticket detail only for the owner", async () => {
+    const ownerResponse = await request(app)
+      .get(`/api/tickets/${ticketId}`)
+      .set("X-Requester-Id", String(ownerId));
+    const otherResponse = await request(app)
+      .get(`/api/tickets/${ticketId}`)
+      .set("X-Requester-Id", String(otherRequesterId));
+
+    expect(ownerResponse.status).toBe(200);
+    expect(ownerResponse.body).toMatchObject({
+      id: ticketId,
+      summary: `${marker} ticket detail`,
+      priority: "High",
+      status: "New",
+    });
+    expect(otherResponse.status).toBe(403);
+  });
+
+  it("lists public attachment metadata without exposing stored filenames", async () => {
+    const response = await request(app)
+      .get(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(ownerId));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: attachmentId,
+        ticketId,
+        originalFilename: "network evidence.txt",
+        mimeType: "text/plain",
+      }),
+      expect.objectContaining({
+        id: removedAttachmentId,
+        removedAt: expect.any(String),
+        removalReason: "Wrong file",
+      }),
+    ]));
+    expect(response.body[0]).not.toHaveProperty("storedFilename");
+  });
+
+  it("downloads an active attachment only for the owner", async () => {
+    const ownerResponse = await request(app)
+      .get(`/api/attachments/${attachmentId}/download?requesterId=${ownerId}`);
+    const otherResponse = await request(app)
+      .get(`/api/attachments/${attachmentId}/download?requesterId=${otherRequesterId}`);
+
+    expect(ownerResponse.status).toBe(200);
+    expect(ownerResponse.headers["content-type"]).toContain("text/plain");
+    expect(ownerResponse.text).toBe(fileBytes.toString());
+    expect(otherResponse.status).toBe(403);
+  });
+
+  it("soft-removes an attachment and blocks future downloads", async () => {
+    const removeResponse = await request(app)
+      .delete(`/api/attachments/${attachmentId}`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ removalReason: "Uploaded newer evidence" });
+    const downloadResponse = await request(app)
+      .get(`/api/attachments/${attachmentId}/download?requesterId=${ownerId}`);
+
+    expect(removeResponse.status).toBe(200);
+    expect(removeResponse.body).toMatchObject({
+      id: attachmentId,
+      removedAt: expect.any(String),
+      removalReason: "Uploaded newer evidence",
+    });
+    expect(downloadResponse.status).toBe(410);
+  });
+
+  it("rejects invalid attachment requests safely", async () => {
+    const invalidTicket = await request(app)
+      .get("/api/tickets/not-a-number")
+      .set("X-Requester-Id", String(ownerId));
+    const missingRequester = await request(app)
+      .get(`/api/tickets/${ticketId}/attachments`);
+    const missingReason = await request(app)
+      .delete(`/api/attachments/${removedAttachmentId}`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ removalReason: "" });
+
+    expect(invalidTicket.status).toBe(400);
+    expect(missingRequester.status).toBe(400);
+    expect(missingReason.status).toBe(400);
+  });
+});

--- a/server/tests/lab-02/ticket-detail-attachments.api.test.ts
+++ b/server/tests/lab-02/ticket-detail-attachments.api.test.ts
@@ -14,9 +14,12 @@ const fileBytes = Buffer.from("TokTickIT attachment download test");
 
 let ownerId: number;
 let otherRequesterId: number;
+let categoryId: number;
+let relatedSystemId: number;
 let ticketId: number;
 let attachmentId: number;
 let removedAttachmentId: number;
+let createdTicketIds: number[] = [];
 
 beforeAll(async () => {
   const [owner, other, category, relatedSystem] = await Promise.all([
@@ -28,6 +31,8 @@ beforeAll(async () => {
 
   ownerId = owner.id;
   otherRequesterId = other.id === owner.id ? owner.id + 1000 : other.id;
+  categoryId = category.id;
+  relatedSystemId = relatedSystem.id;
 
   const ticket = await prisma.ticket.create({
     data: {
@@ -42,6 +47,7 @@ beforeAll(async () => {
     },
   });
   ticketId = ticket.id;
+  createdTicketIds = [ticketId];
 
   mkdirSync(uploadDir, { recursive: true });
   writeFileSync(path.join(uploadDir, storedFilename), fileBytes);
@@ -72,19 +78,44 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await prisma.attachment.deleteMany({ where: { ticketId } });
-  await prisma.ticket.deleteMany({ where: { id: ticketId } });
+  const attachments = await prisma.attachment.findMany({
+    where: { ticketId: { in: createdTicketIds } },
+    select: { storedFilename: true },
+  });
 
-  try {
-    unlinkSync(path.join(uploadDir, storedFilename));
-  } catch {
-    // Test cleanup should not fail if the file was already removed manually.
+  await prisma.attachment.deleteMany({ where: { ticketId: { in: createdTicketIds } } });
+  await prisma.ticket.deleteMany({ where: { id: { in: createdTicketIds } } });
+
+  for (const attachment of attachments) {
+    try {
+      unlinkSync(path.join(uploadDir, attachment.storedFilename));
+    } catch {
+      // Test cleanup should not fail if the file was already removed manually.
+    }
   }
 
   await prisma.$disconnect();
 });
 
 describe("Ticket detail and attachments", () => {
+  async function createOwnedTicket(summary: string) {
+    const ticket = await prisma.ticket.create({
+      data: {
+        ticketNumber: `TK-F17-${Date.now()}-${createdTicketIds.length}`,
+        requesterId: ownerId,
+        categoryId,
+        relatedSystemId,
+        summary,
+        description: "Created only for ticket attachment upload tests.",
+        priority: Priority.MEDIUM,
+        currentStatus: "New",
+      },
+    });
+
+    createdTicketIds.push(ticket.id);
+    return ticket.id;
+  }
+
   it("returns one ticket detail only for the owner", async () => {
     const ownerResponse = await request(app)
       .get(`/api/tickets/${ticketId}`)
@@ -101,6 +132,97 @@ describe("Ticket detail and attachments", () => {
       status: "New",
     });
     expect(otherResponse.status).toBe(403);
+  });
+
+  it("uploads a permitted attachment for the ticket owner", async () => {
+    const validFileBytes = Buffer.from("%PDF-1.4 TokTickIT evidence");
+
+    const response = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(ownerId))
+      .attach("file", validFileBytes, {
+        filename: "valid-evidence.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      ticketId,
+      originalFilename: "valid-evidence.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: validFileBytes.length,
+      removedAt: null,
+      removalReason: null,
+    });
+    expect(response.body).not.toHaveProperty("storedFilename");
+  });
+
+  it("rejects unsupported attachment types", async () => {
+    const ticketForUpload = await createOwnedTicket(`${marker} unsupported type`);
+    const beforeCount = await prisma.attachment.count({ where: { ticketId: ticketForUpload } });
+
+    const response = await request(app)
+      .post(`/api/tickets/${ticketForUpload}/attachments`)
+      .set("X-Requester-Id", String(ownerId))
+      .attach("file", Buffer.from("not allowed"), {
+        filename: "script.exe",
+        contentType: "application/x-msdownload",
+      });
+
+    const afterCount = await prisma.attachment.count({ where: { ticketId: ticketForUpload } });
+
+    expect(response.status).toBe(415);
+    expect(afterCount).toBe(beforeCount);
+  });
+
+  it("rejects attachments larger than 5 MB", async () => {
+    const ticketForUpload = await createOwnedTicket(`${marker} oversized upload`);
+
+    const response = await request(app)
+      .post(`/api/tickets/${ticketForUpload}/attachments`)
+      .set("X-Requester-Id", String(ownerId))
+      .attach("file", Buffer.alloc(5 * 1024 * 1024 + 1, "a"), {
+        filename: "too-large.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(response.status).toBe(413);
+  });
+
+  it("rejects a sixth active attachment", async () => {
+    const ticketForUpload = await createOwnedTicket(`${marker} attachment count limit`);
+
+    await prisma.attachment.createMany({
+      data: Array.from({ length: 5 }, (_, index) => ({
+        ticketId: ticketForUpload,
+        originalFilename: `existing-${index}.pdf`,
+        storedFilename: `feature-17-limit-${ticketForUpload}-${index}.pdf`,
+        mimeType: "application/pdf",
+        sizeBytes: 10,
+      })),
+    });
+
+    const response = await request(app)
+      .post(`/api/tickets/${ticketForUpload}/attachments`)
+      .set("X-Requester-Id", String(ownerId))
+      .attach("file", Buffer.from("%PDF-1.4 sixth"), {
+        filename: "sixth.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(response.status).toBe(409);
+  });
+
+  it("rejects attachment upload from another requester", async () => {
+    const response = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(otherRequesterId))
+      .attach("file", Buffer.from("%PDF-1.4 wrong owner"), {
+        filename: "wrong-owner.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(response.status).toBe(403);
   });
 
   it("lists public attachment metadata without exposing stored filenames", async () => {

--- a/server/tests/lab-02/ticket-detail-attachments.api.test.ts
+++ b/server/tests/lab-02/ticket-detail-attachments.api.test.ts
@@ -189,6 +189,26 @@ describe("Ticket detail and attachments", () => {
     expect(response.status).toBe(413);
   });
 
+  it("accepts an attachment exactly 5 MB in size", async () => {
+    const ticketForUpload = await createOwnedTicket(`${marker} exact size upload`);
+    const exactLimitFile = Buffer.alloc(5 * 1024 * 1024, "a");
+
+    const response = await request(app)
+      .post(`/api/tickets/${ticketForUpload}/attachments`)
+      .set("X-Requester-Id", String(ownerId))
+      .attach("file", exactLimitFile, {
+        filename: "exactly-five-megabytes.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      ticketId: ticketForUpload,
+      originalFilename: "exactly-five-megabytes.pdf",
+      sizeBytes: exactLimitFile.length,
+    });
+  });
+
   it("rejects a sixth active attachment", async () => {
     const ticketForUpload = await createOwnedTicket(`${marker} attachment count limit`);
 
@@ -274,6 +294,17 @@ describe("Ticket detail and attachments", () => {
       removalReason: "Uploaded newer evidence",
     });
     expect(downloadResponse.status).toBe(410);
+  });
+
+  it("rejects removing an attachment more than once without overwriting its reason", async () => {
+    const secondRemoveResponse = await request(app)
+      .delete(`/api/attachments/${attachmentId}`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ removalReason: "A different reason" });
+    const attachment = await prisma.attachment.findUniqueOrThrow({ where: { id: attachmentId } });
+
+    expect(secondRemoveResponse.status).toBe(409);
+    expect(attachment.removalReason).toBe("Uploaded newer evidence");
   });
 
   it("rejects invalid attachment requests safely", async () => {


### PR DESCRIPTION
## Summary

- Added a Ticket Detail screen that opens from My Tickets.
- Added requester-owned API access for ticket details.
- Added attachment metadata list for each ticket.
- Added download links for ticket attachments.
- Added soft-remove for attachments with a removal reason.
- Updated Lab 2 API, UI, test, reviewer, and AI-use docs.

## Testing

- Backend tests pass.
- Backend build passes.
- Frontend tests pass.
- Frontend build passes.
- Manually checked that a requester can open their own ticket detail page and see attachment information.

## Scope note

This PR focuses on ticket detail, attachment inspection, download, and soft removal. Uploading a new attachment from an existing ticket detail page is handled in the next attachment feature.