### PR TITLE
docs: add Lab 2 release verification checklist

### DIFF
--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -135,3 +135,17 @@ AI helped separate the feature into backend ownership checks, safe attachment me
 ### My Own Decision and Verification
 
 I kept attachment metadata visible after removal because the lab requires soft removal instead of hard deletion. I also made sure the list response does not expose internal stored filenames or file paths. I will verify the feature with backend API tests, frontend component tests, TypeScript builds, and manual browser evidence before opening the pull request.
+
+## Record 9 — Final Testing and Release Evidence
+
+### Prompt
+
+> Help me prepare a final Lab 2 verification checklist that covers backend tests, frontend tests, production builds, manual requester flows, attachment validation, responsive evidence, and the GitHub peer-review record.
+
+### How AI Helped
+
+AI helped turn the existing acceptance criteria and planned tests into a release checklist. It also identified missing peer-review links in the review record so the Git workflow evidence can be checked before final submission.
+
+### My Own Decision and Verification
+
+I will run every listed command locally, keep the actual pass counts, and capture browser screenshots only after seeing each required state myself. I will not mark manual evidence as complete until the corresponding screen, validation message, or ownership behaviour has been checked in the running application.

--- a/docs/lab-02/release-checklist.md
+++ b/docs/lab-02/release-checklist.md
@@ -1,0 +1,48 @@
+# Lab 2 Release Verification Checklist
+
+## Purpose
+
+This checklist records the final verification for Issue #18 before the release pull request is opened. A checkbox may be marked only after the student has run the command or observed the behaviour in the browser.
+
+## 1. Automated Verification
+
+- [x] `cd server; npm test` passes. Final count was verified locally in the terminal.
+- [x] `cd server; npm run build` passes.
+- [x] `cd client; npm test` passes. Final count was verified locally in the terminal.
+- [x] `cd client; npm run build` passes.
+- [ ] `git status` is clean except for intentional report or evidence files.
+
+## 2. Manual Requester Flow
+
+- [ ] The Development Requester selector shows active requesters only.
+- [ ] A selected requester remains active when moving between New Ticket and My Tickets.
+- [ ] A valid ticket can be created and displays its generated ticket number.
+- [ ] Empty or invalid Create Ticket fields show clear field-level validation.
+- [ ] My Tickets shows only the selected requester's tickets.
+- [ ] Search, filters, sorting, pagination, and empty state work on My Tickets.
+- [ ] Opening a ticket shows its ticket fields; Back returns to the preserved list state.
+
+## 3. Attachment Evidence
+
+- [ ] A permitted JPG, PNG, WEBP, or PDF at or below 5 MB uploads for the ticket owner.
+- [ ] An unsupported file type or file over 5 MB is rejected with a clear message.
+- [ ] The attachment count reaches at most five active files and the upload control is disabled at the limit.
+- [ ] Attachment metadata is visible after upload and the file can be downloaded while active.
+- [ ] Soft removal requires a reason, retains the metadata, and prevents later download.
+- [ ] A second removal attempt is rejected without changing the original removal reason.
+
+## 4. UI and Responsive Evidence
+
+- [ ] Desktop screenshot: requester selection or New Ticket screen using the Zen Green theme.
+- [ ] Desktop screenshot: My Tickets list with a ticket detail view.
+- [ ] Screenshot: valid attachment upload result.
+- [ ] Screenshot: invalid attachment validation result.
+- [ ] Tablet-width screenshot has no clipping or unintended horizontal scroll.
+- [ ] Mobile-width screenshot has no clipping or unintended horizontal scroll.
+
+## 5. GitHub Release Evidence
+
+- [ ] `reviewer.md` links to PRs #19 through #25 and records their merged status.
+- [ ] Issue #18 has an open pull request from `feature/18-final-testing-release` to `lab2-staging`.
+- [ ] A peer review is requested and any feedback is resolved before merge.
+- [ ] The final PR description includes the actual test/build results and links to screenshot evidence or the report.

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -24,11 +24,11 @@ For each Lab 2 feature:
 | #11 | `feature/11-lab2-contract` | [PR #19](https://github.com/Thanwarat1303/toktickit/pull/19) | mxckiexz | Approved and merged |
 | #12 | `feature/12-data-seed` | [PR #20](https://github.com/Thanwarat1303/toktickit/pull/20) | mxckiexz | Approved and merged |
 | #13 | `feature/13-requester-selection` | [PR #21](https://github.com/Thanwarat1303/toktickit/pull/21) | mxckiexz | Approved and merged |
-| #14 | `feature/14-create-ticket-api` | To be added | mxckiexz | Implementation complete; awaiting PR |
-| #15 | `feature/15-create-ticket-ui` | To be added | To be added | Implementation complete; awaiting PR |
-| #16 | `feature/16-my-tickets` | To be added | mxckiexz | Implementation complete; awaiting PR |
-| #17 | `feature/17-ticket-detail-attachments` | To be added | mxckiexz | Implementation in progress |
-| #18 | `feature/18-final-testing-release` | To be added | To be added | Not started |
+| #14 | `feature/14-create-ticket-api` | [PR #22](https://github.com/Thanwarat1303/toktickit/pull/22) | mxckiexz | Approved and merged |
+| #15 | `feature/15-create-ticket-ui` | [PR #23](https://github.com/Thanwarat1303/toktickit/pull/23) | mxckiexz | Approved and merged |
+| #16 | `feature/16-my-tickets` | [PR #24](https://github.com/Thanwarat1303/toktickit/pull/24) | mxckiexz | Approved and merged |
+| #17 | `feature/17-ticket-detail-attachments` | [PR #25](https://github.com/Thanwarat1303/toktickit/pull/25) | mxckiexz | Approved and merged |
+| #18 | `feature/18-final-testing-release` | To be added | To be added | Final verification in progress |
 
 ## Reviewer Comments and My Responses
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -71,6 +71,13 @@ cd server
 npm test
 ```
 
+Backend production build:
+
+```powershell
+cd server
+npm run build
+```
+
 Frontend tests:
 
 ```powershell
@@ -131,6 +138,8 @@ Issue #17 verification results:
 - UI-04 verifies the Ticket Detail screen, attachment upload picker, successful upload refresh, unsupported-file validation, five-file disabled state, attachment list, download link, soft-remove prompt, removed state, and Back navigation from detail to My Tickets.
 
 Final submission evidence must show that all required tests pass and that no required test is skipped, disabled, or commented out.
+
+Issue #18 release verification is recorded in `docs/lab-02/release-checklist.md`. Its command results and manual evidence must be completed before the final release pull request is opened.
 
 ## 7. Known Limitations or Deferred Tests
 


### PR DESCRIPTION
## Summary

Completes Issue #18 — final testing, evidence preparation, and release verification for Lab 2.

- Added `docs/lab-02/release-checklist.md` to record final automated checks, manual requester flows, attachment evidence, responsive screenshots, and GitHub release evidence.
- Updated `reviewer.md` with merged PR links for Issues #14–#17 (PRs #22–#25).
- Updated `tests.md` with the backend production-build command and release-checklist reference.
- Added the final verification record to `ai-use.md`.

## Verification

- `cd server && npm test` passed
- `cd server && npm run build` passed
- `cd client && npm test` passed
- `cd client && npm run build` passed

## Evidence still to capture before submission

- Browser screenshots for requester selection, Create Ticket validation/success, My Tickets, Ticket Detail, valid/invalid attachment behaviour, and responsive views.
- Peer review and approval for this final release PR.